### PR TITLE
Fix MOSS job timeout and result check

### DIFF
--- a/common/moss.py
+++ b/common/moss.py
@@ -13,39 +13,40 @@ from common.models import Submit
 
 @django_rq.job
 def check_task(task_id):
-    submits = Submit.objects.filter(assignment__task__id=task_id).order_by('-submit_num')
-    m = mosspy.Moss(settings.MOSS_USERID, "c")
+    try:
+        submits = Submit.objects.filter(assignment__task__id=task_id).order_by('-submit_num')
+        m = mosspy.Moss(settings.MOSS_USERID, "c")
 
-    # template files
-    tpl_path = os.path.join(submits[0].assignment.task.dir(), "template")
-    for root, _, files in os.walk(tpl_path):
-        for f in files:
-            m.addBaseFile(os.path.join(root, f))
+        # template files
+        tpl_path = os.path.join(submits[0].assignment.task.dir(), "template")
+        for root, _, files in os.walk(tpl_path):
+            for f in files:
+                m.addBaseFile(os.path.join(root, f))
 
-    processed = set()
-    for submit in submits:
-        if submit.student_id not in processed:
-            processed.add(submit.student_id)
-            for source in submit.all_sources():
-                m.addFile(source.phys, os.path.join(submit.student.username, source.virt))
+        processed = set()
+        for submit in submits:
+            if submit.student_id not in processed:
+                processed.add(submit.student_id)
+                for source in submit.all_sources():
+                    m.addFile(source.phys, os.path.join(submit.student.username, source.virt))
 
-    url = m.send()
-    with tempfile.NamedTemporaryFile() as out:
-        m.saveWebPage(url, out.name)
+        url = m.send()
+        with tempfile.NamedTemporaryFile() as out:
+            m.saveWebPage(url, out.name)
 
-        matches = []
-        with open(out.name) as f:
-            regex = r'<TR>' \
-                '<TD><A HREF="(?P<link>[^"]+)">(?P<first_login>[^/]+)/(?P<first_path>.*?) \((?P<first_percent>\d+)%\)</A>' \
-                '\s*<TD><A HREF="[^"]+">(?P<second_login>[^/]+)/(?P<second_path>.*?) \((?P<second_percent>\d+)%\)</A>' \
-                '\s*<TD[^>]+>(?P<lines>\d+)'
+            matches = []
+            with open(out.name) as f:
+                regex = r'<TR>' \
+                    '<TD><A HREF="(?P<link>[^"]+)">(?P<first_login>[^/]+)/(?P<first_path>.*?) \((?P<first_percent>\d+)%\)</A>' \
+                    '\s*<TD><A HREF="[^"]+">(?P<second_login>[^/]+)/(?P<second_path>.*?) \((?P<second_percent>\d+)%\)</A>' \
+                    '\s*<TD[^>]+>(?P<lines>\d+)'
 
-            for m in re.finditer(regex, f.read()):
-                d = m.groupdict()
-                d['first_percent'] = int(d['first_percent'])
-                d['second_percent'] = int(d['second_percent'])
-                matches.append(d)
+                for m in re.finditer(regex, f.read()):
+                    d = m.groupdict()
+                    d['first_percent'] = int(d['first_percent'])
+                    d['second_percent'] = int(d['second_percent'])
+                    matches.append(d)
 
-            caches['default'].set(f'moss.{task_id}', matches, timeout=60*60*24*10)
-            caches['default'].delete(f'moss.job.{task_id}')
-
+                caches['default'].set(f'moss.{task_id}', matches, timeout=60*60*24*10)
+    finally:
+        caches['default'].delete(f'moss.job.{task_id}')

--- a/web/views/teacher.py
+++ b/web/views/teacher.py
@@ -62,9 +62,9 @@ def teacher_task_moss_check(request, task_id):
             "task": task,
         })
 
-    if request.method == 'POST' or not cache.get(key):
+    if request.method == 'POST' or cache.get(key) is None:
         job = django_rq.enqueue(check_task, task_id)
-        cache.set(key_job, job.id, timeout=None)
+        cache.set(key_job, job.id, timeout=60*60*8)
         return redirect(request.path_info)
 
     threshold = {


### PR DESCRIPTION
Pokud MOSS vrátil `matches = []`, tak `if ... or cache.get(key)` vrátí False, takže se bude ten job resubmittovat pořád dokola. Zároveň jsem radši přidal timeout a vyčistil job z cache, aby tam nevyhníval (např. kdyby MOSS job failnul uprostřed, tak by se ta job cache nikdy nevyčistila a nešlo by MOSS znovu spustit).

Bylo by asi taky fajn to spouštění toho jobu dělat jenom při POST a nastavit POST na `MOSS check` tlačítko.