### PR TITLE
Use break-word instead of break-all in comments

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -132,7 +132,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
   padding: 5px;
   background: #EFEF40D9;
   white-space: pre-line;
-  word-break: break-all;
+  word-break: break-word;
   border: 2px solid #BFBFBF;
   border-radius: 5px;
 }


### PR DESCRIPTION
`break-all` nebyl dobrý nápad :D Lomí to někdy fakt hnusně.