### PR TITLE
Improve handling of failed MOSS jobs and add timestamp to job result

### DIFF
--- a/templates/web/moss.html
+++ b/templates/web/moss.html
@@ -3,15 +3,23 @@
 {% block content %}
 <h1>MOSS for {{ task.name }}
 {% if moss_url %}
-&nbsp;(<a href="{{ moss_url }}" target="_blank">MOSS URL</a>)
+(<a href="{{ moss_url }}" target="_blank">MOSS URL</a>)
 {% endif %}
 </h1>
+{% if timestamp %}
+  <div>Finished {{ timestamp|date:"d. m. Y H:i:s" }}</div>
+{% endif %}
 {% if status %}
   <div style="text-align: center; font-size: 30px">
-    {{ status }}
+    <pre>
+      {{ status }}
+    </pre>
   </div>
-  <meta http-equiv="refresh" content="15" />
+  {% if refresh %}
+    <meta http-equiv="refresh" content="15" />
+  {% endif %}
 {% else %}
+  {% if moss_url %}
   <form method="post" class="float-right">
      {% csrf_token %}
     <button class="btn btn-sm btn-primary"><span class="iconify" data-icon="fa-solid:sync"></span></button>
@@ -79,6 +87,11 @@
   </p>
 
   {% endif %}
+  {% else %}
+    <form method="post">
+     {% csrf_token %}
+      <button class="btn btn-sm btn-primary">Send to MOSS</button>
+    </form>
+  {% endif %}
 {% endif %}
-
 {% endblock %}


### PR DESCRIPTION
This PR reworks how MOSS jobs are handled. What is changed:
1) MOSS jobs are no longer auto-started automatically when you visit the MOSS page to avoid fail-retry chains resulting in many requests to the MOSS server. There is now an explicit button.
2) If a MOSS job fails (either an exception is raised inside the job or the queue somehow misplaces the job), the corresponding job cache key will be kept until you view the page again. When you open the page, the corresponding error (with an exception chain) will be printed and the job (its cache entry) will be removed, so that you can re-submit the job again after reload of the page. In this situation the automatic refresh will be disabled, so that you can read the error.
3) When a new job is submitted, the previous result is deleted. This is to prevent displaying stale results if a job fails.
4) There is now a timestamp displayed on the result page so that you know when the MOSS check happened.