### PR TITLE
Add support for compiling `.NET` projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ kelvin
 ├── api
 ├── evaluator (pipeline for evaluating, linting submits)
 │   ├── images (docker images for custom pipeline actions)
-│   └── pipelines.py (integrated pipeline actions - evaluating in isolate, ...)
+│   └── pipelines.py (integrated pipeline actions - Docker evaluation, ...)
 ├── kelvin (base configuration of the application)
 ├── survey (module for easy surveys defined in yaml)
 └── web (web interface for the kelvin)

--- a/README.pipeline.md
+++ b/README.pipeline.md
@@ -10,7 +10,7 @@ If you add a new Docker pipeline, don't forget to also modify the config validat
 in `frontend/src/PipelineValidation.js` (variable `rules`).
 
 ### The sandbox environment limits
-Submits are evaluated in the sandboxed environment with the help of <a href="https://github.com/ioi/isolate">isolate tool</a>.
+Submits are evaluated in a sandboxed environment using Docker.
 Executing the student's submit is constrained to the <a href="https://github.com/mrlvsb/kelvin/blob/63b6ffc294e3b91d1db13453d487c773764ba4a1/evaluator/testsets.py#L122">default</a> wall clock time, memory, number of created processes etc.
 This can be overriden by the yaml configuration:
 

--- a/evaluator/images/base/Dockerfile
+++ b/evaluator/images/base/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     gdb=12.0.90-0ubuntu1 \
     nasm=2.15.05-1 \
     python3=3.10.4-0ubuntu2 \
-    cmake=3.22.1-1ubuntu1
+    cmake=3.22.1-1ubuntu1 && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8

--- a/evaluator/images/dotnet/Dockerfile
+++ b/evaluator/images/dotnet/Dockerfile
@@ -1,0 +1,12 @@
+FROM kelvin/base
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    dotnet6=6.0.108-0ubuntu1~22.04.1 \
+    aspnetcore-runtime-6.0=6.0.108-0ubuntu1~22.04.1 \
+    python3-pip
+
+RUN python3 -m pip install bleach==5.0.1
+
+ADD entry.py /
+CMD /entry.py

--- a/evaluator/images/dotnet/Dockerfile
+++ b/evaluator/images/dotnet/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     dotnet6=6.0.108-0ubuntu1~22.04.1 \
     aspnetcore-runtime-6.0=6.0.108-0ubuntu1~22.04.1 \
-    python3-pip
+    python3-pip && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install bleach==5.0.1
 

--- a/evaluator/images/dotnet/entry.py
+++ b/evaluator/images/dotnet/entry.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python3
+
+import dataclasses
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+import bleach
+
+
+@dataclasses.dataclass
+class BuildResult:
+    success: bool
+    stderr: Optional[str] = None
+    stdout: Optional[str] = None
+    binaries: Optional[List[Path]] = None
+
+    @staticmethod
+    def fail(stdout: str = "", stderr: str = "") -> "BuildResult":
+        return BuildResult(
+            success=False,
+            stdout=stdout,
+            stderr=stderr
+        )
+
+
+def build_dotnet_project(output_name: str) -> BuildResult:
+    # Rename .csprof file to <output-name>.csproj
+    paths = os.listdir(os.getcwd())
+    csproj = [p for p in paths if Path(p).suffix == ".csproj"]
+    if not csproj:
+        return BuildResult.fail(stderr="No .csproj file was found")
+    elif len(csproj) > 1:
+        return BuildResult.fail(stderr="Multiple .csproj files were found")
+    else:
+        csproj = csproj[0]
+        os.rename(csproj, f"{output_name}.csproj")
+
+    artifact_dir = "build"
+
+    env = os.environ.copy()
+    env["DOTNET_CLI_HOME"] = "/tmp/dotnet-cli-home"
+
+    logging.info("Building dotnet project")
+
+    # Build the .NET project
+    result = subprocess.run([
+        "dotnet",
+        "publish",
+        "-o", artifact_dir,
+        "--self-contained", "true",
+        "--runtime", "linux-x64",
+        "/p:PublishSingleFile=true"
+    ],
+        env=env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE)
+    if result.returncode != 0:
+        return BuildResult(
+            success=False,
+            stderr=result.stderr.decode(),
+            stdout=result.stdout.decode(),
+        )
+
+    # Try to find binary
+    binary_path = Path(artifact_dir) / output_name
+    binaries = []
+    if os.access(binary_path, os.X_OK):
+        binaries.append(binary_path)
+    return BuildResult(
+        success=True,
+        stderr=result.stderr.decode(),
+        stdout=result.stdout.decode(),
+        binaries=binaries
+    )
+
+
+output = os.getenv("PIPE_OUTPUT", "main")
+
+result = build_dotnet_project(output_name=output)
+
+with open("result.html", "w") as out:
+    if not result.success:
+        stdout = bleach.clean(result.stdout.strip()).replace("\n", "<br />")
+        stderr = bleach.clean(result.stderr.strip()).replace("\n", "<br />")
+        out.write("<span style='color: red'>Project was not compiled successfully!</span>")
+        if stderr:
+            out.write(f"<div>Stderr<br />{stderr}</div>")
+        if stdout:
+            out.write(f"<div>Stdout<br />{stdout}</div>")
+        exit(1)
+
+    bins = result.binaries
+    if len(bins) == 0:
+        out.write("<span style='color: red'>No executable has been built.</span>")
+        exit(1)
+    elif len(bins) > 1:
+        out.write(
+            f"<span style='color: red'>Multiple executables have been built: "
+            f"{','.join([bleach.clean(bin.name) for bin in bins])}</span>")
+        exit(1)
+    else:
+        out.write("<div>Project was successfully built</div>")
+        out.write(
+            f"<code style='color: #444; font-weight: bold'>$ mv "
+            f"{bleach.clean(str(bins[0]))} {output}</code>")
+        os.rename(bins[0], output)

--- a/evaluator/images/pythonrun/Dockerfile
+++ b/evaluator/images/pythonrun/Dockerfile
@@ -1,4 +1,7 @@
 FROM kelvin/run
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip
+RUN apt-get update &&  \
+    apt-get install -y --no-install-recommends python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip3 install -U pip wheel setuptools
 RUN pip3 install pytest

--- a/evaluator/images/run/Dockerfile
+++ b/evaluator/images/run/Dockerfile
@@ -1,4 +1,8 @@
 FROM kelvin/base
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y asciinema imagemagick webp python3-magic
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y asciinema imagemagick webp python3-magic && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD entry.py /
 CMD /entry.py

--- a/evaluator/pipelines.py
+++ b/evaluator/pipelines.py
@@ -243,14 +243,14 @@ class TestsPipe:
             cmd = [self.executable] + test.args
 
             with tempfile.NamedTemporaryFile() as stdout_name, tempfile.NamedTemporaryFile() as stderr_name:
-                isolate_cmd = shlex.split(f"docker exec -i {container}") + ['timeout', str(self.timeout)] + cmd
+                docker_cmd = shlex.split(f"docker exec -i {container}") + ['timeout', str(self.timeout)] + cmd
                 logger.debug("executing in isolation: %s",
-                                " ".join((isolate_cmd)))  # TODO: shlex.join only in python3.8
+                                " ".join((docker_cmd)))  # TODO: shlex.join only in python3.8
                 def preexec_fn():
                     import resource
                     fsize = parse_human_size(DEFAULT_LIMITS['fsize'])
                     resource.setrlimit(resource.RLIMIT_FSIZE, (fsize, fsize))
-                p = subprocess.Popen(isolate_cmd, **args, stdout=stdout_name, stderr=stderr_name, preexec_fn=preexec_fn)
+                p = subprocess.Popen(docker_cmd, **args, stdout=stdout_name, stderr=stderr_name, preexec_fn=preexec_fn)
                 p.communicate(**comm_args)
 
                 result['exit_code'] = p.returncode

--- a/evaluator/pipelines.py
+++ b/evaluator/pipelines.py
@@ -53,9 +53,13 @@ def create_docker_cmd(evaluation, image, additional_args=None, cmd=None, limits=
         additional_args.append("-v")
         additional_args.append(f"{template_path}:/template:ro")
 
+    network = limits["network"]
+    # Forcefully disable using --network=host
+    if network == "host":
+        network = "bridge"
     return [
         'docker', 'run', '--rm',
-        '--network', limits["network"],
+        '--network', network,
         '-w', '/work',
         '-v', evaluation.submit_path + ':/work',
         '--ulimit', f'fsize={limits["fsize"]}:{limits["fsize"]}',

--- a/evaluator/pipelines.py
+++ b/evaluator/pipelines.py
@@ -18,6 +18,7 @@ logger = logging.getLogger('evaluator')
 DEFAULT_LIMITS = {
     'fsize': '16M',
     'memory': '128M',
+    'network': 'none'
 }
 
 
@@ -25,7 +26,9 @@ def create_docker_cmd(evaluation, image, additional_args=None, cmd=None, limits=
     if not limits:
         limits = {}
     limits = {**DEFAULT_LIMITS, **limits}
-    limits = {k: parse_human_size(v) for k, v in limits.items()}
+    for (k, v) in limits.items():
+        if k in ("fsize", "memory"):
+            limits[k] = parse_human_size(v)
 
     if not cmd:
         cmd = []
@@ -52,7 +55,7 @@ def create_docker_cmd(evaluation, image, additional_args=None, cmd=None, limits=
 
     return [
         'docker', 'run', '--rm',
-        '--network', 'none',
+        '--network', limits["network"],
         '-w', '/work',
         '-v', evaluation.submit_path + ':/work',
         '--ulimit', f'fsize={limits["fsize"]}:{limits["fsize"]}',

--- a/frontend/src/PipelineValidation.js
+++ b/frontend/src/PipelineValidation.js
@@ -387,7 +387,7 @@ class DockerPipeRule extends PipeRule {
             limits: [new DictRule({
               fsize: [new ValueRule(), 'Maximal size for one created file. You can use suffixes like 16M'],
               memory: [new ValueRule(), 'Maximal memory use for the container, not the process. You can use suffixes like 128M'],
-              network: [new EnumRule(["none", "host"]), '"none" to disable network access (default) or "host" to enable it'],
+              network: [new EnumRule(["none", "bridge"]), '"none" to disable network access (default) or "bridge" to enable it'],
             }), 'Container runtime limits like file size or maximal memory use'],
         })
     }

--- a/frontend/src/PipelineValidation.js
+++ b/frontend/src/PipelineValidation.js
@@ -387,6 +387,7 @@ class DockerPipeRule extends PipeRule {
             limits: [new DictRule({
               fsize: [new ValueRule(), 'Maximal size for one created file. You can use suffixes like 16M'],
               memory: [new ValueRule(), 'Maximal memory use for the container, not the process. You can use suffixes like 128M'],
+              network: [new EnumRule(["none", "host"]), '"none" to disable network access (default) or "host" to enable it'],
             }), 'Container runtime limits like file size or maximal memory use'],
         })
     }
@@ -428,6 +429,9 @@ const rules = new DictRule({
         args: [new ArrayRule(new ValueRule()), 'Array of arguments passed to the program'],
     })),
     pipeline: new PipelineRule({
+        dotnet: [new DockerPipeRule({
+            output: [new ValueRule(), 'Built executable name <strong>(default: main)</strong>']
+        })],
         gcc: [new DockerPipeRule({
             flags: [new ValueRule(), 'Flags for the gcc/g++ compiler.'],
             output: [new ValueRule(), 'Built executable name <strong>-o main</strong>'],


### PR DESCRIPTION
It wasn't straightforward to get it working, but hopefully something like this should work for simple projects. Network access has to be enabled in order to build a standalone binary, sadly. We could get around it by building a .NET framework dependent binary, but then all additional steps (like `run`, `tests` etc.) would need to be executed inside Docker, which is annoying.