### PR TITLE
Set XDG_DATA_HOME when executing dotnet command

### DIFF
--- a/evaluator/images/dotnet/Dockerfile
+++ b/evaluator/images/dotnet/Dockerfile
@@ -2,8 +2,8 @@ FROM kelvin/base
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    dotnet6 \
-    aspnetcore-runtime-6.0 \
+    dotnet6=6.0.110-0ubuntu1~22.04.1 \
+    aspnetcore-runtime-6.0=6.0.110-0ubuntu1~22.04.1 \
     python3-pip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/evaluator/images/dotnet/entry.py
+++ b/evaluator/images/dotnet/entry.py
@@ -75,6 +75,8 @@ def build_dotnet_project(run_tests: bool) -> BuildResult:
     tests_path = "tests.xml"
     env = os.environ.copy()
     env["DOTNET_CLI_HOME"] = "/tmp/dotnet-cli-home"
+    # workaround for https://github.com/dotnet/core/issues/7868
+    env["XDG_DATA_HOME"] = "/tmp/dotnet-cli-home"
     env["DOTNET_NOLOGO"] = "1"
     cmd = ['dotnet']
     if run_tests:


### PR DESCRIPTION
Since the upgrade to Dotnet 6.0.10, there was a permission denied error (https://github.com/dotnet/core/issues/7868). The version of dotnet is now also pinned in the Dockerfile.

![image](https://user-images.githubusercontent.com/4539057/195977517-e4e67c21-9e06-425c-9319-d56600dfe427.png)