### PR TITLE
Improve support for multiple projects in dotnet pipeline

### DIFF
--- a/evaluator/images/dotnet/entry.py
+++ b/evaluator/images/dotnet/entry.py
@@ -84,9 +84,9 @@ def build_dotnet_project(run_tests: bool) -> BuildResult:
     csproj = [p for p in paths if Path(p).suffix == ".csproj"]
 
     if sln and csproj:
-        return BuildResult.fail("Both .sln and .csproj file was found.")
+        return BuildResult.fail("Both .sln and .csproj file was found in the root directory.")
     if not sln and not csproj:
-        return BuildResult.fail("No .sln or .csproj file was found")
+        return BuildResult.fail("No .sln or .csproj file was found in the root directory.")
     if len(sln) > 1:
         return BuildResult.fail("Multiple .sln files were found")
     if len(csproj) > 1:


### PR DESCRIPTION
Now we try to find a `.csproj` file with `OutputType` set to `Exe`, and use its name for searching for the binary.