### PR TITLE
Fix (temporarily) - comments are overlapping with quick buttons #175

### DIFF
--- a/frontend/src/CodeRow.svelte
+++ b/frontend/src/CodeRow.svelte
@@ -41,7 +41,7 @@
     word-break: break-word;
     border: 2px solid #000000;
     border-radius: 5px;
-    max-width: 980px;
+    max-width: 960px;
     margin-bottom: 1px;
   }
   :global(.comment p) {


### PR DESCRIPTION
On the teacher page, which displays user submissions, comments can overlap with quick buttons on the right.

The temporary fix is shown below with the changed value. But a better fix for the future would be with a flexbox, because it is more flexible for future’s adjustments (adding more icons, etc.)
