### PR TITLE
Fix - Overlapping icons #175

### DIFF
--- a/frontend/src/Comment.svelte
+++ b/frontend/src/Comment.svelte
@@ -36,25 +36,27 @@
     }
 </script>
 
-<div class="comment comment-{unread ? 'unread' : 'read'} {type}" on:dblclick={() => editing = can_edit}>
-  <strong>{author}</strong>: 
-  {#if !editing}
-    {#if type == 'automated'}
-      {text}
-      {#if url}
-        <a href="{url}">
-          <span class="iconify" data-icon="entypo:help"></span>
-        </a>
+  <div style="display: flex; flex-direction: row;">
+    <div class="comment comment-{unread ? 'unread' : 'read'} {type}" on:dblclick={() => editing = can_edit}>
+      <strong>{author}</strong>:
+      {#if !editing}
+        {#if type == 'automated'}
+          {text}
+          {#if url}
+            <a href="{url}">
+              <span class="iconify" data-icon="entypo:help"></span>
+            </a>
+          {/if}
+        {:else if $user}
+          {#if unread && type != 'automated' && author_id != $user.id}
+            <button class="btn p-0 float-right" on:click|preventDefault={handleNotification} style="line-height: normal">
+              <span class="iconify" data-icon="cil-check"></span>
+            </button>
+          {/if}
+          {@html safeMarkdown(text)}
+        {/if}
+      {:else}
+        <CommentForm comment={text} on:save={updateComment} disabled={sending} />
       {/if}
-    {:else if $user}
-      {#if unread && type != 'automated' && author_id != $user.id}
-        <button class="btn p-0 float-right" on:click|preventDefault={handleNotification} style="line-height: normal">
-          <span class="iconify" data-icon="cil-check"></span>
-        </button>
-      {/if}
-      {@html safeMarkdown(text)}
-    {/if}
-  {:else}
-    <CommentForm comment={text} on:save={updateComment} disabled={sending} />
-  {/if}
-</div>
+    </div>
+  </div> 

--- a/frontend/src/TaskDetail.svelte
+++ b/frontend/src/TaskDetail.svelte
@@ -215,7 +215,7 @@
     <SyncLoader />
   </div>
 {:else}
-  <div class="float-right">
+  <div class="float-right" >
     {#if files.length > 1}
       <button class="btn btn-link p-0" on:click={toggleOpen} title="Expand or collapse all files">
         {#if allOpen}


### PR DESCRIPTION
On the teacher's page, where user submissions are displayed, comments can overlap with the quick buttons on the right.

What it looked like before: https://ctrlv.link/cLNp
What does it look like now after the fix: https://ctrlv.link/WRcl
If new icons were added in the future, it would look like this: https://ctrlv.link/LXYL