### PR TITLE
Disabling `draggable` attribute

### DIFF
--- a/frontend/src/Notifications.svelte
+++ b/frontend/src/Notifications.svelte
@@ -26,7 +26,7 @@ async function openNotification(notification) {
 {#if $notifications}
 <span style="position: relative" use:clickOutside on:click_outside={() => show = false}>
     <span on:click={() => show = !show} style="cursor: pointer">
-      <img src="/static/notify_icon.png" style="height: 15px;" />
+      <img src="/static/notify_icon.png" style="height: 15px;" draggable="false" />
       {#if $notificationsCount > 0}
         <span class="badge badge-pill {$importantNotificationsCount >= 1 ? 'badge-danger' : 'badge-warning'}" style="margin-left: -3px">{$notificationsCount}</span>
       {/if}


### PR DESCRIPTION
Disabling `draggable` attribute on notification icon so that the icon can't be dragged and submitted when released, like happened to me. The submitted work looks like this:
![Screenshot_20230309_094425](https://user-images.githubusercontent.com/18398260/224107305-2b005e08-5ab2-4d5d-a68d-7f3528112a28.png)
