### PR TITLE
Set "Show this semester only" to be checked by default again

### DIFF
--- a/templates/web/moss.html
+++ b/templates/web/moss.html
@@ -125,7 +125,7 @@
         </script>
 
         <div style="display: flex; justify-content: end;">
-          <input type="checkbox" id="this-semester" />
+          <input type="checkbox" checked="checked" id="this-semester" />
           <span style="padding-left: 5px;">Show only this semester</span>
         </div>
         <table class="table table-sm table-hover table-striped moss-table">


### PR DESCRIPTION
I misunderstood how it worked, it should be enabled, because it only shows entries where at least one of the students is from the current semester, which is what we want.