### PR TITLE
Fix displaying of MOSS sources

### DIFF
--- a/common/moss/__init__.py
+++ b/common/moss/__init__.py
@@ -446,8 +446,13 @@ def moss_task_get_opts(task_id: int) -> MossTaskOptions:
 def moss_result(
     task_id: int,
     percent: Optional[int] = None,
-    lines: Optional[int] = None
+    lines: Optional[int] = None,
+    filtered: bool = True
 ) -> Optional[MossResult]:
+    """
+    If `filtered` is True, matches will be filtered according to saved or passed filter options.
+    """
+
     cache = caches["default"]
 
     key = moss_result_cache_key(task_id)
@@ -462,8 +467,8 @@ def moss_result(
         opts.lines = lines
 
     matches = []
-    for match in cache_entry["matches"]:
-        if is_match_suspicious(match, opts):
+    for match in cache_entry.get("matches", []):
+        if (not filtered) or is_match_suspicious(match, opts):
             matches.append(match)
 
     return MossResult(


### PR DESCRIPTION
Before, MOSS result matches were automatically filtered and the match list was indexed by match ID. However, if some entries were filtered (which happened almost all the time), indexing by ID would yield incorrect results. Now matches are looked-up using their ID instead of using it directly as a list index.

Additionally, MOSS results can now be displayed for results that do not pass through the currently active filter. Adding the flag is dirty, but the `MossResult` API would need to be refactored completely to solve this easily in a different way.