### PR TITLE
Separate comment count badges for user and bot comments

### DIFF
--- a/frontend/src/TaskDetail.svelte
+++ b/frontend/src/TaskDetail.svelte
@@ -171,7 +171,20 @@
 
   function countComments(comments) {
       comments = comments || {};
-      return Object.values(comments).reduce((sum, line) => sum + line.length, 0);
+      const counts = {
+          user: 0,
+          automated: 0
+      };
+      for (const line of Object.values(comments)) {
+          for (const comment of Object.values(line)) {
+              if (comment.type === "automated") {
+                  counts.automated += 1;
+              } else {
+                  counts.user += 1;
+              }
+          }
+      }
+      return counts;
   }
 
   $: allOpen = files && files.reduce((sum, file) => sum + file.opened, 0) === files.length;
@@ -220,6 +233,9 @@
   .file-header span:hover {
       text-decoration: underline;
   }
+  .file-header span .badge:hover {
+      text-decoration: none;
+  }
 </style>
 
 {#if files === null}
@@ -251,11 +267,17 @@
   <SummaryComments {summaryComments} on:saveComment={evt => saveComment(evt.detail)} on:setNotification={setNotification} />
 
   {#each files as file}
-    <h2 class="file-header" title="Toggle file visibility">
+    <h2 class="file-header">
       <span on:click={() => file.opened = !file.opened}>
-      {file.source.path}
+      <span title="Toggle file visibility">{file.source.path}</span>
       {#if file.source.comments && Object.keys(file.source.comments).length}
-        <span class="badge bg-secondary" style="font-size: .6em;">{countComments(file.source.comments)}</span>
+        {@const comments = countComments(file.source.comments)}
+        {#if comments.user > 0 }
+          <span class="badge bg-secondary" title="Student/teacher comments" style="font-size: 60%;">{comments.user}</span>
+        {/if}
+        {#if comments.automated > 0 }
+          <span class="badge bg-primary" title="Automation comments" style="font-size: 60%;">{comments.automated}</span>
+        {/if}
       {/if}
       </span>{#if file.source.type == 'source' && file.source.content}<CopyToClipboard content={() => file.source.content} title='Copy the source code to the clipboard'><span class="iconify" data-icon="clarity:copy-to-clipboard-line" style="height: 20px"></span></CopyToClipboard>{/if}
     </h2>

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -647,7 +647,7 @@ def submit_comments(request, assignment_id, login, submit_num):
             else:
                 max_lines = result[comment.source]['content'].count('\n')
                 line = 0 if comment.line > max_lines else comment.line
-                result[comment.source]['comments'].setdefault(comment.line - 1, []).append(dump_comment(comment))
+                result[comment.source]['comments'].setdefault(line - 1, []).append(dump_comment(comment))
         except KeyError as e:
             logging.exception(e)
 


### PR DESCRIPTION
It is nice to know quickly whether some file has user comments. But at the same time, for students it's useful to see automated comments too. So I split the comment counter into two.

![image](https://github.com/mrlvsb/kelvin/assets/4539057/d92da307-c35a-43f4-86d5-a10ac5b4a240)

Fixes: https://github.com/mrlvsb/kelvin/issues/176