### PR TITLE
Add comment count to submit diff

### DIFF
--- a/frontend/src/SubmitsDiff.svelte
+++ b/frontend/src/SubmitsDiff.svelte
@@ -10,6 +10,21 @@
 
     let diffHtmlOutput = '';
 
+    function formatInfo(submit) {
+        let result = "(";
+        if (submit.points !== null) {
+            result += `${submit.points} point${submit.points !== 1 ? 's' : ''}`;
+        }
+        if (submit.comments > 0) {
+            if (submit.points != null) {
+                result += ', ';
+            }
+            result += `${submit.comments} comment${submit.comments !== 1 ? 's' : ''}`;
+        }
+
+        return `${result})`;
+    }
+
     $: if(a != b) {
         fetch(`../${a}-${b}.diff`)
           .then((result) => result.text())
@@ -45,8 +60,8 @@
                 {new Date(submit.submitted).toLocaleString('cs')}
             {/if}
 
-            {#if submit.points != null}
-                <span class="text-muted">({submit.points} points)</span>
+            {#if submit.points != null || submit.comments > 0}
+                <span class="text-muted">{formatInfo(submit)}</span>
             {/if}
         </li>
     {/each}

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -478,6 +478,7 @@ def submit_comments(request, assignment_id, login, submit_num):
             'num': s.submit_num,
             'submitted': s.created_at,
             'points': s.assigned_points,
+            'comments': s.comment_set.count()
         })
 
     def get_comment_type(comment):


### PR DESCRIPTION
Svelte sadly doesn't support whitespace trimming between tags, so I implemented the formatting of the info row in JavaScript.

![image](https://github.com/mrlvsb/kelvin/assets/4539057/7823a9e3-7b3e-43e2-891a-ba855be380ae)

Fixes: https://github.com/mrlvsb/kelvin/issues/177