### PR TITLE
Increase default pipeline limits for Cargo

### DIFF
--- a/evaluator/pipelines.py
+++ b/evaluator/pipelines.py
@@ -26,6 +26,11 @@ IMAGE_LIMITS = {
         'network': 'bridge',
         'memory': '512M',
         'fsize': '128M',
+    },
+    'kelvin/cargo': {
+        'network': 'bridge',
+        'memory': '512M',
+        'fsize': '128M',
     }
 }
 


### PR DESCRIPTION
The default limits didn't allow downloading crates from crates.io, and also caused OOM/disk errors even for simple code.