### PR TITLE
Sort files in test results

### DIFF
--- a/evaluator/results.py
+++ b/evaluator/results.py
@@ -33,6 +33,10 @@ class TestResult:
             'stderr': 'err'
         }
 
+    @property
+    def files_sorted(self):
+        return sorted(self.files.items(), key=lambda k: k[0])
+
     def discover_files(self):
         aliases = {v: k for k, v in self.aliases.items()}
 

--- a/templates/web/report.html
+++ b/templates/web/report.html
@@ -44,7 +44,7 @@
 </pre>
 {% endif %}
 
-            {% for path, v in test.files.items %}
+            {% for path, v in test.files_sorted %}
             {% if v.diff and v.diff.size < max_inline_content_bytes or not max_inline_content_bytes %}
               <div class="code-diff diff"
                 data-expected-url="{% url 'raw_result_content' submit.id test.name 'expected' path %}"
@@ -73,6 +73,7 @@
                         <a href="{% url 'raw_result_content' submit.id test.name 'expected' path %}">expected output</a>
                       </span>
                       {% endif %}
+                    </span>
                   </div>
                   <div class="d2h-file-diff">
                     <div class="d2h-code-wrapper">


### PR DESCRIPTION
To keep `stdin` before `stdout` in a deterministic way. This code should live in the view/presenter, but Django doesn't really make that easy…