### PR TITLE
INBUS: Change caching of listing subject versions

### DIFF
--- a/common/inbus/views.py
+++ b/common/inbus/views.py
@@ -1,6 +1,5 @@
 import serde.json
 
-from django.core.cache import cache
 from django.contrib.auth.decorators import user_passes_test
 from django.http import HttpResponse
 
@@ -11,10 +10,7 @@ from common.utils import is_teacher
 
 @user_passes_test(is_teacher)
 def subject_versions(request):
-    subject_versions = cache.get('subject_versions')
-    if not subject_versions:
-        subject_versions = inbus.subject_versions()
-        cache.set('subject_versions', subject_versions, 60*60)
+    subject_versions = inbus.subject_versions()
 
     # TODO: When upgrading, see: https://docs.djangoproject.com/en/4.2/ref/request-response/#httpresponse-objects
     # for a way to set content type.


### PR DESCRIPTION
This enables caching of INBUS request to get all subject versions system wide, not only through web API.