### PR TITLE
Include runner script in tests archive

### DIFF
--- a/web/views/assets/run-tests.sh
+++ b/web/views/assets/run-tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+TABLE_OUTPUT=""
+BINARY=${1:-./main}
+
+if [ -f ${BINARY} ]
+then
+  RESULT=""
+  for dir in */
+  do
+    ARGS=""
+    if [ -f ${dir}args ]
+    then
+      ARGS=$(cat ${dir}args)
+    fi
+    ${BINARY} ${ARGS} < ${dir}stdin > ${dir}real_stdout 2> ${dir}real_stderr
+    if ( [ ! -f ${dir}stdout ] || cmp --silent -- ${dir}stdout ${dir}real_stdout ) && ( [ ! -f ${dir}stderr ] || cmp --silent -- ${dir}stderr ${dir}real_stderr )
+    then
+      TABLE_OUTPUT="${TABLE_OUTPUT}${dir}:\t\u001b[32;1mSUCCESS\u001b[0m\n"
+    else
+      TABLE_OUTPUT="${TABLE_OUTPUT}${dir}:\t\u001b[31;1mFAILED\u001b[0m\n"
+      if [ -f ${dir}stdout ]
+      then
+        git diff --no-index ${dir}real_stdout ${dir}stdout > ${dir}stdout.diff
+      fi
+      if [ -f ${dir}stderr ]
+      then
+        git diff --no-index ${dir}real_stderr ${dir}stderr > ${dir}stderr.diff
+      fi
+      RESULT="ERROR"
+    fi
+  done
+
+  echo -e "${TABLE_OUTPUT}" | column -t
+
+  if [ ${RESULT} ]
+  then
+    echo "You can find the program's outputs stored as \"real_stdout\" and output differences as \"stdout.diff\" in tests directories."
+  fi
+else
+  echo -e "\u001b[31;1mERROR:\u001b[0m Binary not found."
+fi

--- a/web/views/assets/run-tests.sh
+++ b/web/views/assets/run-tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Usage: ./run-tests.sh <path-to-binary>
+# Example: ./run-tests.sh ./main
+
 TABLE_OUTPUT=""
 BINARY=${1:-./main}
 BINARY=$(realpath "${BINARY}")

--- a/web/views/assets/run-tests.sh
+++ b/web/views/assets/run-tests.sh
@@ -2,6 +2,7 @@
 
 TABLE_OUTPUT=""
 BINARY=${1:-./main}
+BINARY=$(realpath "${BINARY}")
 
 execute_test () {
   ${BINARY} $2 < $1/stdin > $1/real_stdout 2> $1/real_stderr

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -734,6 +734,9 @@ def tar_test_data(request, task_name):
         contents = io.BytesIO(bytes(File(path).open('r').read().replace("# --kelvin-generate--", generated_content), "utf-8"))
         info = tarfile.TarInfo(script_name)
         info.size = len(contents.getvalue())
+        # Owner: rwx, group: rwx, other: r
+        info.mode = 0o774
+
         tar.addfile(info, fileobj=contents)
 
     task = get_object_or_404(Task, code=task_name)

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -35,7 +35,7 @@ from common.evaluate import evaluate_submit
 from common.moss import PlagiarismMatch, moss_result
 from web.task_utils import load_readme
 from kelvin.settings import BASE_DIR, MAX_INLINE_CONTENT_BYTES, MAX_INLINE_LINES
-from evaluator.testsets import TestSet
+from evaluator.testsets import File, TestSet
 from common.evaluate import get_meta
 from evaluator.results import EvaluationResult, PipeResult
 from common.utils import is_teacher
@@ -728,6 +728,14 @@ def check_is_task_accessible(request, task):
 
 @login_required
 def tar_test_data(request, task_name):
+    def include_tests_script(tar):
+        script_name = "run-tests.sh"
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", script_name)
+        file = File(path)
+        info = tarfile.TarInfo(script_name)
+        info.size = file.size()
+        tar.addfile(info, fileobj=file.open('rb'))
+
     task = get_object_or_404(Task, code=task_name)
     check_is_task_accessible(request, task)
 
@@ -740,11 +748,18 @@ def tar_test_data(request, task_name):
     with io.BytesIO() as f:
         with tarfile.open(fileobj=f, mode="w:gz") as tar:
             for test in tests:
+                if len(test.args) > 0:
+                    args = " ".join(test.args)
+                    file = io.BytesIO(bytes(args, "utf-8"))
+                    info = tarfile.TarInfo(os.path.join(test.name, "args"))
+                    info.size = len(args)
+                    tar.addfile(info, fileobj=file)
                 for file_path in test.files:
                     test_file = test.files[file_path]
                     info = tarfile.TarInfo(os.path.join(test.name, file_path))
                     info.size = test_file.size()
                     tar.addfile(info, fileobj=test_file.open('rb'))
+            include_tests_script(tar)
 
         f.seek(0)
         return file_response(f, f"{task_name}.tar.gz", "application/tar")

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -726,12 +726,17 @@ def check_is_task_accessible(request, task):
         if not assigned_tasks:
             raise PermissionDenied()
 
+
+ASSETS_DIR = Path(__file__).absolute().parent / "assets"
+
+
 @login_required
 def tar_test_data(request, task_name):
     def include_tests_script(tar, generated_content):
         script_name = "run-tests.sh"
-        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", script_name)
-        contents = io.BytesIO(bytes(File(path).open('r').read().replace("# --kelvin-generate--", generated_content), "utf-8"))
+        with File(ASSETS_DIR / script_name).open('r') as f:
+            contents = io.BytesIO(
+                bytes(f.read().replace("# --kelvin-generate--", generated_content), "utf-8"))
         info = tarfile.TarInfo(script_name)
         info.size = len(contents.getvalue())
         # Owner: rwx, group: rwx, other: r


### PR DESCRIPTION
To simplify local testing, a bash script was created. It compares the executable's standard output with `stdout` file (and similarly for `stderr`). On differences a `git diff` output is saved. It is now included with every downloaded archive of all tests. Due to many different types of tasks `args` are bundled as a separate file and if it is present, then it is passed to executable.