### PR TITLE
Ask before uploading dropped solution

### DIFF
--- a/frontend/src/Modal.svelte
+++ b/frontend/src/Modal.svelte
@@ -1,0 +1,46 @@
+<script>
+import {fade, fly} from "svelte/transition";
+import {quintOut} from "svelte/easing";
+
+export let open = false;
+export let showBackdrop = true;
+export let onClosed;
+export let title = '';
+export let cancelButtonLabel = 'Cancel';
+export let proceedButtonLabel = 'Proceed';
+
+function modalClose(data) {
+	open = false;
+	if (onClosed)
+		onClosed(data);
+}
+</script>
+
+<style>
+.modal {
+	display: block;
+}
+</style>
+
+{#if open}
+	<div class="modal" id="kelvin-modal" tabindex="-1" role="dialog" aria-labelledby="Modal" aria-hidden={false}>
+		<div class="modal-dialog" role="document" in:fly={{ y: -50, duration: 300 }} out:fly={{ y: -50, duration: 300, easing: quintOut }}>
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="sampleModalLabel">{title}</h5>
+					<button type="button" class="btn-close" data-dismiss="modal" aria-label="Close" on:click={() => modalClose(false)}></button>
+				</div>
+				<div class="modal-body">
+					<slot></slot>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-dismiss="modal" on:click={() => modalClose(false)}>{cancelButtonLabel}</button>
+					<button type="button" class="btn btn-primary" on:click={() => modalClose(true)}>{proceedButtonLabel}</button>
+				</div>
+			</div>
+		</div>
+	</div>
+	{#if showBackdrop}
+		<div class="modal-backdrop show" transition:fade={{ duration: 150 }} />
+	{/if}
+{/if}

--- a/frontend/src/UploadSolution.svelte
+++ b/frontend/src/UploadSolution.svelte
@@ -2,9 +2,13 @@
 import {csrfToken} from './api.js'
 import uppie from 'uppie'
 import {localStorageStore} from './utils.js'
+import Modal from './Modal.svelte';
 
 export let cooldown = 0;
 
+let showUploadQuestion = false;
+let filesQuestion = [];
+let uploadFormData = null;
 let dropping = false;
 let dragLeaveTimer = null;
 let progress = null;
@@ -38,12 +42,25 @@ uppie()(window, {name: 'solution'}, async (event, formData, files) => {
 	if(files.length) {
 		formData.append('paths', files.join('\n'));
 		if(remainingMS <= 0) {
-			upload(formData);
+			uploadFormData = formData;
+			filesQuestion = files;
+			showUploadQuestion = true;
 		} else {
 			queued = formData;
 		}
 	}
 });	
+
+function acceptUpload() {
+	showUploadQuestion = false;
+	upload(uploadFormData);
+}
+
+function declineUpload() {
+	showUploadQuestion = false;
+	uploadFormData = null;
+	filesQuestion = [];
+}
 
 function dragstop() {
 	if(dragLeaveTimer) {
@@ -181,3 +198,14 @@ update();
 		<span><span class="iconify" data-icon="ic:baseline-file-upload" data-inline="false"></span></span>
 	{/if}
 </div>
+
+<Modal open={showUploadQuestion} onClosed={(proceed) => proceed ? acceptUpload() : declineUpload()} title="Submit source code">
+	<p>
+		<strong>Do you really want to submit these files?</strong>
+	</p>
+	<ul>
+		{#each filesQuestion as file}
+			<li>{file}</li>
+		{/each}
+	</ul>
+</Modal>

--- a/frontend/src/UploadSolution.svelte
+++ b/frontend/src/UploadSolution.svelte
@@ -38,7 +38,7 @@
     }
 
     uppie()(window, {name: 'solution'}, async (event, formData, files) => {
-        if (files.length) {
+        if (files.length && uploadFormData === null) {
             formData.append('paths', files.join('\n'));
             if (remainingMS <= 0) {
                 uploadFormData = formData;
@@ -82,7 +82,7 @@
             return false;
         }
 
-        if (hasFiles() && !dropping) {
+        if (uploadFormData === null && hasFiles() && !dropping) {
             dropping = true;
         }
     }

--- a/frontend/src/UploadSolution.svelte
+++ b/frontend/src/UploadSolution.svelte
@@ -6,7 +6,6 @@
 
     export let cooldown = 0;
 
-    let showUploadQuestion = false;
     let filesQuestion = [];
     let uploadFormData = null;
     let dropping = false;
@@ -44,7 +43,6 @@
             if (remainingMS <= 0) {
                 uploadFormData = formData;
                 filesQuestion = files;
-                showUploadQuestion = true;
             } else {
                 queued = formData;
             }
@@ -52,12 +50,11 @@
     });
 
     function acceptUpload() {
-        showUploadQuestion = false;
         upload(uploadFormData);
+        clearFormData();
     }
 
-    function declineUpload() {
-        showUploadQuestion = false;
+    function clearFormData() {
         uploadFormData = null;
         filesQuestion = [];
     }
@@ -211,7 +208,7 @@
   {/if}
 </div>
 
-<Modal open={showUploadQuestion} onClosed={(proceed) => proceed ? acceptUpload() : declineUpload()}
+<Modal open={uploadFormData !== null} onClosed={(proceed) => proceed ? acceptUpload() : clearFormData()}
        title="Submit source code">
   <p>
     <strong>Do you really want to submit these files?</strong>

--- a/frontend/src/UploadSolution.svelte
+++ b/frontend/src/UploadSolution.svelte
@@ -1,211 +1,227 @@
 <script>
-import {csrfToken} from './api.js'
-import uppie from 'uppie'
-import {localStorageStore} from './utils.js'
-import Modal from './Modal.svelte';
+    import {csrfToken} from './api.js'
+    import uppie from 'uppie'
+    import {localStorageStore} from './utils.js'
+    import Modal from './Modal.svelte';
 
-export let cooldown = 0;
+    export let cooldown = 0;
 
-let showUploadQuestion = false;
-let filesQuestion = [];
-let uploadFormData = null;
-let dropping = false;
-let dragLeaveTimer = null;
-let progress = null;
-let error = false;
-let lastSubmitDate = localStorageStore('KELVIN_LAST_SUBMIT_DATE', 0);
-let remainingMS = -1;
-let queued = null;
+    let showUploadQuestion = false;
+    let filesQuestion = [];
+    let uploadFormData = null;
+    let dropping = false;
+    let dragLeaveTimer = null;
+    let progress = null;
+    let error = false;
+    let lastSubmitDate = localStorageStore('KELVIN_LAST_SUBMIT_DATE', 0);
+    let remainingMS = -1;
+    let queued = null;
 
-function upload(formData) {
-	progress = 0;
-	const xhr = new XMLHttpRequest();
-	xhr.upload.addEventListener("progress", e => {
-		if (e.lengthComputable) {
-			progress = Math.round(e.loaded * 100 / e.total);
-		}
-	}, false);
-	xhr.addEventListener('loadend', () => {
-		if(xhr.status == 200 && xhr.responseURL) {
-			$lastSubmitDate = new Date();
-			document.location.href = xhr.responseURL + '#result';
-		} else {
-			error = true;
-		}
-	});
-	xhr.open('POST', document.location.href);
-	xhr.setRequestHeader('X-CSRFToken', csrfToken())
-	xhr.send(formData);
-}
+    function upload(formData) {
+        progress = 0;
+        const xhr = new XMLHttpRequest();
+        xhr.upload.addEventListener("progress", e => {
+            if (e.lengthComputable) {
+                progress = Math.round(e.loaded * 100 / e.total);
+            }
+        }, false);
+        xhr.addEventListener('loadend', () => {
+            if (xhr.status == 200 && xhr.responseURL) {
+                $lastSubmitDate = new Date();
+                document.location.href = xhr.responseURL + '#result';
+            } else {
+                error = true;
+            }
+        });
+        xhr.open('POST', document.location.href);
+        xhr.setRequestHeader('X-CSRFToken', csrfToken())
+        xhr.send(formData);
+    }
 
-uppie()(window, {name: 'solution'}, async (event, formData, files) => {
-	if(files.length) {
-		formData.append('paths', files.join('\n'));
-		if(remainingMS <= 0) {
-			uploadFormData = formData;
-			filesQuestion = files;
-			showUploadQuestion = true;
-		} else {
-			queued = formData;
-		}
-	}
-});	
+    uppie()(window, {name: 'solution'}, async (event, formData, files) => {
+        if (files.length) {
+            formData.append('paths', files.join('\n'));
+            if (remainingMS <= 0) {
+                uploadFormData = formData;
+                filesQuestion = files;
+                showUploadQuestion = true;
+            } else {
+                queued = formData;
+            }
+        }
+    });
 
-function acceptUpload() {
-	showUploadQuestion = false;
-	upload(uploadFormData);
-}
+    function acceptUpload() {
+        showUploadQuestion = false;
+        upload(uploadFormData);
+    }
 
-function declineUpload() {
-	showUploadQuestion = false;
-	uploadFormData = null;
-	filesQuestion = [];
-}
+    function declineUpload() {
+        showUploadQuestion = false;
+        uploadFormData = null;
+        filesQuestion = [];
+    }
 
-function dragstop() {
-	if(dragLeaveTimer) {
-		clearInterval(dragLeaveTimer);
-	}
-	dragLeaveTimer = setTimeout(() => dropping = false, 300);
-}
+    function dragstop() {
+        if (dragLeaveTimer) {
+            clearInterval(dragLeaveTimer);
+        }
+        dragLeaveTimer = setTimeout(() => dropping = false, 300);
+    }
 
-function dragstart(e) {
-	if(dragLeaveTimer) {
-		clearInterval(dragLeaveTimer);
-	}
+    function dragstart(e) {
+        if (dragLeaveTimer) {
+            clearInterval(dragLeaveTimer);
+        }
 
-	function hasFiles() {
-		if (e.dataTransfer.types) {
-			for(const t of e.dataTransfer.types) {
-				if(t == 'Files') {
-					return true;
-				}
-			}
-		}
-		return false;
-	}	
+        function hasFiles() {
+            if (e.dataTransfer.types) {
+                for (const t of e.dataTransfer.types) {
+                    if (t == 'Files') {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
 
-	if(hasFiles() && !dropping) {
-		dropping = true;
-	}
-}
+        if (hasFiles() && !dropping) {
+            dropping = true;
+        }
+    }
 
-function dismiss() {
-	if(!error && !queued) {
-		return;
-	}
+    function dismiss() {
+        if (!error && !queued) {
+            return;
+        }
 
-	error = false;
-	dropping = false;
-	progress = null;
-	queued = null;
-}
+        error = false;
+        dropping = false;
+        progress = null;
+        queued = null;
+    }
 
-const btn = document.getElementById('upload-choose');
-btn.onchange = function() {
-	$lastSubmitDate = new Date();
-	this.form.submit();
-};
-const btnText = btn.nextElementSibling;
+    const btn = document.getElementById('upload-choose');
+    btn.onchange = function () {
+        $lastSubmitDate = new Date();
+        this.form.submit();
+    };
+    const btnText = btn.nextElementSibling;
 
-function update() {
-	try {
-		const target = new Date();
-		target.setUTCMilliseconds(target.getUTCMilliseconds() - cooldown * 1000);
-		remainingMS = new Date($lastSubmitDate) - target;
-	} catch(e) {}
+    function update() {
+        try {
+            const target = new Date();
+            target.setUTCMilliseconds(target.getUTCMilliseconds() - cooldown * 1000);
+            remainingMS = new Date($lastSubmitDate) - target;
+        } catch (e) {
+        }
 
-	if(remainingMS <= 0) {
-		btn.removeAttribute('disabled');
-		btnText.classList.remove('disabled');
-		btnText.innerText = "Upload";
+        if (remainingMS <= 0) {
+            btn.removeAttribute('disabled');
+            btnText.classList.remove('disabled');
+            btnText.innerText = "Upload";
 
-		if(queued) {
-			const formData = queued;
-			console.log(queued)
-			upload(formData);
-		}
-		return;
-	}
+            if (queued) {
+                const formData = queued;
+                console.log(queued)
+                upload(formData);
+            }
+            return;
+        }
 
-	btn.setAttribute('disabled', 'disabled');
-	btnText.classList.add('disabled');
-	btnText.innerText = "next upload in " + Math.ceil(remainingMS / 1000) + " seconds";
-	setTimeout(update, 1000);
-}
-update();
+        btn.setAttribute('disabled', 'disabled');
+        btnText.classList.add('disabled');
+        btnText.innerText = "next upload in " + Math.ceil(remainingMS / 1000) + " seconds";
+        setTimeout(update, 1000);
+    }
+
+    const MAXIMUM_FILE_SHOWN = 20;
+
+    function uploadFileList() {
+        return filesQuestion.slice(0, MAXIMUM_FILE_SHOWN);
+    }
+    function uploadFileRest() {
+        return Math.max(0, filesQuestion.length - MAXIMUM_FILE_SHOWN);
+    }
+
+    update();
 </script>
 
 <svelte:window
-	on:dragleave={dragstop}
-	on:drop={dragstop}
-	on:dragenter={dragstart}
-	on:dragover={dragstart}
-	/>
+    on:dragleave={dragstop}
+    on:drop={dragstop}
+    on:dragenter={dragstart}
+    on:dragover={dragstart}
+/>
 
 <style>
-	.dropzone {
-		position: fixed;
-		z-index: 10;
-		top: 0;
-		left: 0;
-		width: 100vw;
-		height: 100vh;
-		transition: background-color 100ms;
-		visibility: hidden;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 10rem;
-		text-align: center;
-	}
+    .dropzone {
+        position: fixed;
+        z-index: 10;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        transition: background-color 100ms;
+        visibility: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 10rem;
+        text-align: center;
+    }
 
-	.dropzone.uploading:not(.dropzone.error) {
-		cursor: wait;
-	}
+    .dropzone.uploading:not(.dropzone.error) {
+        cursor: wait;
+    }
 
-	.dropzone.dropping, .dropzone.uploading, .dropzone.queued {
-		visibility: visible;
-		background: #007bff50;
-	}
+    .dropzone.dropping, .dropzone.uploading, .dropzone.queued {
+        visibility: visible;
+        background: #007bff50;
+    }
 
-	.dropzone.queued {
-		font-size: 3rem;
-	}
+    .dropzone.queued {
+        font-size: 3rem;
+    }
 
-	.dropzone.error {
-		background: #f5c6cbcc;
-		font-size: 3rem;
-	}
+    .dropzone.error {
+        background: #f5c6cbcc;
+        font-size: 3rem;
+    }
 </style>
 
 <div class="dropzone"
-	class:dropping={dropping}
-	class:uploading={progress != null}
-	class:queued={queued}
-	class:error={error}
-	on:click={dismiss}>
-	{#if error}
+     class:dropping={dropping}
+     class:uploading={progress != null}
+     class:queued={queued}
+     class:error={error}
+     on:click={dismiss}>
+  {#if error}
 		<span class="text-danger">
 			Upload failed.<br>
 			Try again or use the upload button.
 		</span>
-	{:else if queued}
-		uploading in {Math.ceil(remainingMS/1000)} seconds...
-	{:else if progress != null}
-		{progress}%
-	{:else} 
-		<span><span class="iconify" data-icon="ic:baseline-file-upload" data-inline="false"></span></span>
-	{/if}
+  {:else if queued}
+    uploading in {Math.ceil(remainingMS / 1000)} seconds...
+  {:else if progress != null}
+    {progress}%
+  {:else}
+    <span><span class="iconify" data-icon="ic:baseline-file-upload"
+                data-inline="false"></span></span>
+  {/if}
 </div>
 
-<Modal open={showUploadQuestion} onClosed={(proceed) => proceed ? acceptUpload() : declineUpload()} title="Submit source code">
-	<p>
-		<strong>Do you really want to submit these files?</strong>
-	</p>
-	<ul>
-		{#each filesQuestion as file}
-			<li>{file}</li>
-		{/each}
-	</ul>
+<Modal open={showUploadQuestion} onClosed={(proceed) => proceed ? acceptUpload() : declineUpload()}
+       title="Submit source code">
+  <p>
+    <strong>Do you really want to submit these files?</strong>
+  </p>
+  <ul>
+    {#each uploadFileList() as file}
+      <li>{file}</li>
+    {/each}
+  </ul>
+  {#if uploadFileRest() > 0}
+    <span>and {uploadFileRest()} other file(s).</span>
+  {/if}
 </Modal>


### PR DESCRIPTION
When dropping files to browser, a question modal is shown to make sure user really wants to submit these files. Modal also contains list of dropped files.
Example:
![image](https://github.com/mrlvsb/kelvin/assets/53856821/74c8abc2-f4d2-418d-9f05-a254bc7a3052)
However, in some cases, I received this file list and I think I can't impact that behavior since these uploads will fail.
![image](https://github.com/mrlvsb/kelvin/assets/53856821/f58ebde9-e03e-443f-a0f4-dab200cdd6e8)
The modal component was retrieved and modified from https://eternaldev.com/blog/using-bootstrap-modal-in-svelte.