### PR TITLE
Add background to code in comments

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -9,6 +9,13 @@ html[data-bs-theme="dark"] {
   @include meta.load-css('node_modules/flatpickr/dist/themes/dark.css');
   @include meta.load-css('node_modules/codemirror/theme/dracula.css');
 
+  .comment code {
+    display: inline-block;
+    background-color: var(--bs-card-bg);
+    border: var(--bs-card-border-width) solid var(--bs-card-border-color);
+    border-radius: var(--bs-card-border-radius);
+  }
+
   .code-diff {
     .d2h-ins {
       background-color: #748a74;


### PR DESCRIPTION
As requested by @fpeterek. Applies only for dark mode.
Example:
![image](https://github.com/mrlvsb/kelvin/assets/53856821/77ca6714-3e63-4bf0-b783-c889294cc221)
