### PR TITLE
Disable default select options

### DIFF
--- a/frontend/src/ClassDetail.svelte
+++ b/frontend/src/ClassDetail.svelte
@@ -166,7 +166,7 @@ tr td:not(:nth-of-type(1)):not(:nth-of-type(2)):not(:last-child) {
       {#if showStudentsList}
         {#if clazz.summary }
           <button class="p-0 btn btn-link"
-                    on:click={() => showSummary = !showSummary}>{showSummary ? "Hide" : "Show"} exercise summary</button>
+                    on:click={() => showSummary = !showSummary}>{showSummary ? "Hide" : "Show"} class summary</button>
           {#if showSummary }
             <Markdown content={clazz.summary} />
           {/if}

--- a/frontend/src/ClassDetail.svelte
+++ b/frontend/src/ClassDetail.svelte
@@ -166,7 +166,7 @@ tr td:not(:nth-of-type(1)):not(:nth-of-type(2)):not(:last-child) {
       {#if showStudentsList}
         {#if clazz.summary }
           <button class="p-0 btn btn-link"
-                    on:click={() => showSummary = !showSummary}>{showSummary ? "Skrýt" : "Zobrazit"} informace o cvičení</button>
+                    on:click={() => showSummary = !showSummary}>{showSummary ? "Hide" : "Show"} exercise summary</button>
           {#if showSummary }
             <Markdown content={clazz.summary} />
           {/if}
@@ -228,7 +228,7 @@ tr td:not(:nth-of-type(1)):not(:nth-of-type(2)):not(:last-child) {
                   </div>
                 </th>
                 {/each}
-                <th>Celkem ({clazz.assignments.reduce((sum, task)=>sum + task.max_points, 0)} b)</th>
+                <th>Total ({clazz.assignments.reduce((sum, task)=>sum + task.max_points, 0)} pts)</th>
               </tr>
             </thead>
 

--- a/frontend/src/ClassFilter.svelte
+++ b/frontend/src/ClassFilter.svelte
@@ -117,7 +117,7 @@
 <div class="ms-auto">
   <div class="input-group">
     <select class="form-select form-select-sm" bind:value={semester} on:change={resetClass}>
-        <option value="" disabled>Semester</option>
+        <option value="">Semester</option>
         {#each sorted(Object.keys(semesters), compare_semester) as semester (semester)}
             <option>{semester}</option>
         {/each}

--- a/frontend/src/ClassFilter.svelte
+++ b/frontend/src/ClassFilter.svelte
@@ -117,14 +117,14 @@
 <div class="ms-auto">
   <div class="input-group">
     <select class="form-select form-select-sm" bind:value={semester} on:change={resetClass}>
-        <option value="">Semester</option>
+        <option value="" disabled>Semester</option>
         {#each sorted(Object.keys(semesters), compare_semester) as semester (semester)}
             <option>{semester}</option>
         {/each}
     </select>
 
     <select class="form-select form-select-sm" bind:value={subject} on:change={fillTeacher} disabled={!semester}>
-        <option value="">Subject</option>
+        <option value="" disabled>Subject</option>
         {#if semesters && semesters[semester]}
             {#each sorted(Object.keys(semesters[semester])) as subj (subj)}
                 <option>{subj}</option>
@@ -134,14 +134,14 @@
 
     {#if $user.is_superuser}
       <select class="form-select form-select-sm" bind:value={teacher} on:change={resetClass}>
-          <option value="">Teacher</option>
+          <option value="" disabled>Teacher</option>
             {#each sorted(teachers) as teacher (teacher)}
                 <option>{teacher}</option>
             {/each}
       </select>
     {/if}
     <select class="form-select form-select-sm" bind:value={clazz} disabled={!(semester && subject)}>
-      <option value="">Class</option>
+      <option value="" disabled>Class</option>
       <!-- `classes` are sorted serverside -->
       {#each classes as clazz (clazz)}
         <option>{clazz}</option>

--- a/frontend/src/ClassFilter.svelte
+++ b/frontend/src/ClassFilter.svelte
@@ -124,7 +124,7 @@
     </select>
 
     <select class="form-select form-select-sm" bind:value={subject} on:change={fillTeacher} disabled={!semester}>
-        <option value="" disabled>Subject</option>
+        <option value="">Subject</option>
         {#if semesters && semesters[semester]}
             {#each sorted(Object.keys(semesters[semester])) as subj (subj)}
                 <option>{subj}</option>
@@ -134,14 +134,14 @@
 
     {#if $user.is_superuser}
       <select class="form-select form-select-sm" bind:value={teacher} on:change={resetClass}>
-          <option value="" disabled>Teacher</option>
+          <option value="">Teacher</option>
             {#each sorted(teachers) as teacher (teacher)}
                 <option>{teacher}</option>
             {/each}
       </select>
     {/if}
     <select class="form-select form-select-sm" bind:value={clazz} disabled={!(semester && subject)}>
-      <option value="" disabled>Class</option>
+      <option value="">Class</option>
       <!-- `classes` are sorted serverside -->
       {#each classes as clazz (clazz)}
         <option>{clazz}</option>

--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -83,9 +83,9 @@
                 </tr>
                 {% endfor %}
                 <tr>
-                <td colspan="3">Total</td>
-                <td class="text-end">{{ node.earned_points|floatformat:2 }}</td>
-                <td class="text-end">{{ node.max_points|floatformat:2 }}</td>
+                <th colspan="3">Total</th>
+                <th class="text-end">{{ node.earned_points|floatformat:2 }}</th>
+                <th class="text-end">{{ node.max_points|floatformat:2 }}</th>
                 </tr>
             </table>
         </div>

--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -6,7 +6,7 @@
     <div class="row">
         <form class="mb-1 col-sm-3 offset-sm-9 p-0">
             <select name="semester" class="form-select form-select-sm" onchange="this.value != '' && this.form.submit()">
-                <option value=''>Semester</option>
+                <option value='' disabled>Semester</option>
                 {% for s in semesters %}
                     <option value="{{ s.value }}"{% if selected_semester == s.value %} selected{% endif %}>
                         {{ s.label }}
@@ -83,7 +83,7 @@
                 </tr>
                 {% endfor %}
                 <tr>
-                <td colspan="3">Celkem</td>
+                <td colspan="3">Total</td>
                 <td class="text-end">{{ node.earned_points|floatformat:2 }}</td>
                 <td class="text-end">{{ node.max_points|floatformat:2 }}</td>
                 </tr>


### PR DESCRIPTION
In my opinion, options like `Semester` etc. should not be selected since they are representing some kind of heading. I have set them to `disabled`. We could alternatively use `optgroup` for that, but that's a small detail.

I also found some Czech word in student index template. I have replaced that with this commit because it was just minimal change for a separate commit :)