### PR TITLE
Add duplicate buttons to TimeRange

### DIFF
--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -312,7 +312,7 @@ td:not(:nth-of-type(3)) {
               <td>{ clazz.teacher }</td>
               <td>
                 <div class="row">
-                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} onFromDuplicateClick={assignAssignedDateToAll} onToDuplicateClick={assignDeadlineToAll} />
+                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} onFromDuplicateClick={setAssignedDateToVisible} onToDuplicateClick={setDeadlineToAssigned} />
                   <div class="col-md">
                     <div class="input-group">
                       <input class="form-control form-control-sm" type="number" min=0 step=1 disabled={!clazz.assigned} bind:value={clazz.max_points} placeholder="Max points" />

--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -156,7 +156,7 @@
     }
   }
 
-  function assignAssignedDateToAll(assigned) {
+  function setAssignedDateToVisible(assigned) {
     task.classes = task.classes.map(cl => {
       if(isClassVisible(cl))
         cl.assigned = assigned;
@@ -164,7 +164,7 @@
     });
   }
 
-  function assignDeadlineToAll(deadline) {
+  function setDeadlineToAssigned(deadline) {
     task.classes = task.classes.map(cl => {
       if(cl.assigned)
         cl.deadline = deadline;

--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -312,7 +312,7 @@ td:not(:nth-of-type(3)) {
               <td>{ clazz.teacher }</td>
               <td>
                 <div class="row">
-                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} onFromDuplicateClick={assignAssignedDateToAll} fromDuplicateDisabled={!clazz.assigned} onToDuplicateClick={assignDeadlineToAll} toDuplicateDisabled={!clazz.assigned} />
+                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} onFromDuplicateClick={assignAssignedDateToAll} onToDuplicateClick={assignDeadlineToAll} />
                   <div class="col-md">
                     <div class="input-group">
                       <input class="form-control form-control-sm" type="number" min=0 step=1 disabled={!clazz.assigned} bind:value={clazz.max_points} placeholder="Max points" />

--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -156,6 +156,22 @@
     }
   }
 
+  function assignAssignedDateToAll(assigned) {
+    task.classes = task.classes.map(cl => {
+      if(isClassVisible(cl))
+        cl.assigned = assigned;
+      return cl;
+    });
+  }
+
+  function assignDeadlineToAll(deadline) {
+    task.classes = task.classes.map(cl => {
+      if(cl.assigned)
+        cl.deadline = deadline;
+      return cl;
+    });
+  }
+
   function assignPointsToAll(max_pts) {
     task.classes = task.classes.map(cl => {
       if(cl.assigned) {
@@ -296,7 +312,7 @@ td:not(:nth-of-type(3)) {
               <td>{ clazz.teacher }</td>
               <td>
                 <div class="row">
-                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} />
+                  <TimeRange timeOffsetInWeek={clazz.week_offset} bind:from={clazz.assigned} bind:to={clazz.deadline} semesterBeginDate={$semester.begin} onFromDuplicateClick={assignAssignedDateToAll} fromDuplicateDisabled={!clazz.assigned} onToDuplicateClick={assignDeadlineToAll} toDuplicateDisabled={!clazz.assigned} />
                   <div class="col-md">
                     <div class="input-group">
                       <input class="form-control form-control-sm" type="number" min=0 step=1 disabled={!clazz.assigned} bind:value={clazz.max_points} placeholder="Max points" />

--- a/frontend/src/TimeRange.svelte
+++ b/frontend/src/TimeRange.svelte
@@ -4,6 +4,10 @@
   export let to;
 	export let timeOffsetInWeek;
 	export let semesterBeginDate;
+  export let onFromDuplicateClick = undefined;
+  export let fromDuplicateDisabled = false;
+  export let onToDuplicateClick = undefined;
+  export let toDuplicateDisabled = false;
 
   let fromEl, toEl;
   let instanceFrom, instanceTo
@@ -67,6 +71,11 @@ $: if(instanceTo) {
     {/each}
   </ul>
   <input bind:this={fromEl} class="form-control" bind:value={from} placeholder="Assigned">
+  {#if typeof onFromDuplicateClick === 'function'}
+    <button class="btn btn-sm btn-secondary" title="Set assigned date to all visible classes" disabled={fromDuplicateDisabled} on:click|preventDefault={() => onFromDuplicateClick(from)}>
+      <span class="iconify" data-icon="mdi:content-duplicate"></span>
+    </button>
+  {/if}
 </div>
 
 <div class="input-group input-group-sm col-md">
@@ -82,4 +91,9 @@ $: if(instanceTo) {
     <button class="dropdown-item" on:click={() => addDeadline(60*24*7)}>+ week</button>
   </ul>
   <input bind:this={toEl} class="form-control" bind:value={to} placeholder="Deadline">
+  {#if typeof onToDuplicateClick === 'function'}
+    <button class="btn btn-sm btn-secondary" title="Set deadline to all assigned classes" disabled={toDuplicateDisabled} on:click|preventDefault={() => onToDuplicateClick(to)}>
+      <span class="iconify" data-icon="mdi:content-duplicate"></span>
+    </button>
+  {/if}
 </div>

--- a/frontend/src/TimeRange.svelte
+++ b/frontend/src/TimeRange.svelte
@@ -4,10 +4,8 @@
   export let to;
 	export let timeOffsetInWeek;
 	export let semesterBeginDate;
-  export let onFromDuplicateClick = undefined;
-  export let fromDuplicateDisabled = false;
-  export let onToDuplicateClick = undefined;
-  export let toDuplicateDisabled = false;
+  export let onFromDuplicateClick;
+  export let onToDuplicateClick;
 
   let fromEl, toEl;
   let instanceFrom, instanceTo
@@ -71,11 +69,9 @@ $: if(instanceTo) {
     {/each}
   </ul>
   <input bind:this={fromEl} class="form-control" bind:value={from} placeholder="Assigned">
-  {#if typeof onFromDuplicateClick === 'function'}
-    <button class="btn btn-sm btn-secondary" title="Set assigned date to all visible classes" disabled={fromDuplicateDisabled} on:click|preventDefault={() => onFromDuplicateClick(from)}>
-      <span class="iconify" data-icon="mdi:content-duplicate"></span>
-    </button>
-  {/if}
+  <button class="btn btn-sm btn-secondary" title="Set assigned date to all visible classes" disabled={from === undefined} on:click|preventDefault={() => onFromDuplicateClick(from)}>
+    <span class="iconify" data-icon="mdi:content-duplicate"></span>
+  </button>
 </div>
 
 <div class="input-group input-group-sm col-md">
@@ -91,9 +87,7 @@ $: if(instanceTo) {
     <button class="dropdown-item" on:click={() => addDeadline(60*24*7)}>+ week</button>
   </ul>
   <input bind:this={toEl} class="form-control" bind:value={to} placeholder="Deadline">
-  {#if typeof onToDuplicateClick === 'function'}
-    <button class="btn btn-sm btn-secondary" title="Set deadline to all assigned classes" disabled={toDuplicateDisabled} on:click|preventDefault={() => onToDuplicateClick(to)}>
-      <span class="iconify" data-icon="mdi:content-duplicate"></span>
-    </button>
-  {/if}
+  <button class="btn btn-sm btn-secondary" title="Set deadline to all assigned classes" disabled={to === undefined} on:click|preventDefault={() => onToDuplicateClick(to)}>
+    <span class="iconify" data-icon="mdi:content-duplicate"></span>
+  </button>
 </div>

--- a/frontend/src/TimeRange.svelte
+++ b/frontend/src/TimeRange.svelte
@@ -51,6 +51,10 @@ $: if(instanceFrom) {
 }
 $: if(instanceTo) {
   instanceTo.setDate(to);
+  if (!from)
+    instanceTo._input.setAttribute('disabled', 'disabled');
+  else if (instanceTo._input.hasAttribute('disabled'))
+    instanceTo._input.removeAttribute('disabled');
 }
 
 
@@ -69,13 +73,13 @@ $: if(instanceTo) {
     {/each}
   </ul>
   <input bind:this={fromEl} class="form-control" bind:value={from} placeholder="Assigned">
-  <button class="btn btn-sm btn-secondary" title="Set assigned date to all visible classes" disabled={from === undefined} on:click|preventDefault={() => onFromDuplicateClick(from)}>
+  <button class="btn btn-sm btn-secondary" title="Set assigned date to all visible classes" disabled={!from} on:click|preventDefault={() => onFromDuplicateClick(from)}>
     <span class="iconify" data-icon="mdi:content-duplicate"></span>
   </button>
 </div>
 
 <div class="input-group input-group-sm col-md">
-  <button class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button" aria-expanded="false"></button>
+  <button class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button" aria-expanded="false" disabled={!from}></button>
   <ul class="dropdown-menu">
     <button class="dropdown-item" on:click={() => addDeadline(30)}>+ 30 min</button>
     <button class="dropdown-item" on:click={() => addDeadline(1*45)}>+ 1×45 min</button>
@@ -87,7 +91,7 @@ $: if(instanceTo) {
     <button class="dropdown-item" on:click={() => addDeadline(60*24*7)}>+ week</button>
   </ul>
   <input bind:this={toEl} class="form-control" bind:value={to} placeholder="Deadline">
-  <button class="btn btn-sm btn-secondary" title="Set deadline to all assigned classes" disabled={to === undefined} on:click|preventDefault={() => onToDuplicateClick(to)}>
+  <button class="btn btn-sm btn-secondary" title="Set deadline to all assigned classes" disabled={!to} on:click|preventDefault={() => onToDuplicateClick(to)}>
     <span class="iconify" data-icon="mdi:content-duplicate"></span>
   </button>
 </div>


### PR DESCRIPTION
Closes #386.
When a callback is set for duplicate buttons (`onFromDuplicateClick`, `onToDuplicateClick`), these buttons are displayed. The callbacks should accept one argument: the date to be assigned. The buttons can also be disabled using props `fromDuplicateDisabled` and `toDuplicateDisabled`.
The extra props in `TimeRange` are optional and thus they need a default value.