### PR TITLE
Django 5: Packages & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y libsasl2-dev libgraphviz-dev graphviz pandoc
 
 COPY requirements.txt /kelvin/requirements.txt
+RUN pip install --upgrade pip
 RUN pip install -r /kelvin/requirements.txt
 
 RUN apt-get update \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 beautifulsoup4==4.11.1
 bokeh==2.3.2
 cssselect==1.1.0
-django-cas-ng==4.2.1
+django-cas-ng==5.0.1
 django-notifications-hq==1.6.0
 django-redis-cache==2.1.1
-django-rq==2.3.2
+django-rq==2.8.1
 django-webpush==0.3.2
-django==3.1.14
+Django==5.0.4
 imageio==2.6.1
 Jinja2==2.11.3
 lxml==5.1.0
@@ -30,3 +30,4 @@ rq-scheduler==0.11.0
 six==1.16.0
 typing_extensions==4.11.0
 Unidecode==1.3.6
+


### PR DESCRIPTION
This is Draft PR for future upgrade of Django and corresponding libraries in future.

The [django-rq-scheduler](https://pypi.org/project/readwise-django-rq-scheduler/) is unmaintained so we have to use [django-tasks-scheduler](https://github.com/dsoftwareinc/django-tasks-scheduler) in Django 5.

Tasks:
- [x] Migrate to [django-tasks-scheduler](https://github.com/dsoftwareinc/django-tasks-scheduler)
- [x] #281 