### PR TITLE
Fix for nested *.sln files

### DIFF
--- a/evaluator/images/dotnet/entry.py
+++ b/evaluator/images/dotnet/entry.py
@@ -96,7 +96,7 @@ def build_dotnet_project(run_tests: bool) -> BuildResult:
     
     if not sln and not csproj:
         nested_sln_path = find_nested_sln(os.getcwd())
-        if nested_sln_path == None
+        if nested_sln_path is None:
             return BuildResult.fail("No .sln or .csproj file was found in the root directory.")
     if len(sln) > 1:
         return BuildResult.fail("Multiple .sln files were found")


### PR DESCRIPTION
In new versions of .NET, it is unfortunately possible for the *.sln file to be in the directory of one of the projects (and still references another project).

So for example:
- project1
	- project1.csproj
	- project.sln
- project2
	- project2.csproj
	

This change is supposed to be a fallback that addresses one special case. It also addresses the inability of students to upload the correct directory structure.