### PR TITLE
Move test file contents to Svelte

### DIFF
--- a/frontend/src/TestFile.svelte
+++ b/frontend/src/TestFile.svelte
@@ -1,0 +1,42 @@
+<script>
+  import SyncLoader from "./SyncLoader.svelte";
+
+  export let url;
+  export let path;
+  let folded = true;
+  let fetched = false;
+  let data = null;
+  const maxInlineContentBytes = 64565;
+
+  async function getRawFile() {
+    if (!fetched) {
+      const res = await fetch(url);
+      fetched = true;
+      if (res.ok && parseInt(res.headers.get("Content-Length")) <= maxInlineContentBytes) {
+        data = await res.text();
+      }
+    }
+  }
+</script>
+
+<div class="card mb-3">
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <button class="btn" on:click={() => folded = !folded}>
+      <h5>{ path }</h5>
+    </button>
+    <a href="{ url }">Raw content</a>
+  </div>
+    {#if !folded}
+      <div class="card-body">
+      {#await getRawFile()}
+        <SyncLoader />
+      {:then}
+        {#if data == null}
+          Content too large, show <a href="{ url }">raw content</a>.
+        {:else}
+          <pre>{ data }</pre>
+        {/if}
+      {/await}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/TestFile.svelte
+++ b/frontend/src/TestFile.svelte
@@ -3,16 +3,16 @@
 
   export let url;
   export let path;
-  let folded = true;
+  export let max_bytes;
+  let folded = false;
   let fetched = false;
   let data = null;
-  const maxInlineContentBytes = 64565;
 
   async function getRawFile() {
     if (!fetched) {
       const res = await fetch(url);
       fetched = true;
-      if (res.ok && parseInt(res.headers.get("Content-Length")) <= maxInlineContentBytes) {
+      if (res.ok && parseInt(res.headers.get("Content-Length")) <= parseInt(max_bytes)) {
         data = await res.text();
       }
     }
@@ -21,22 +21,22 @@
 
 <div class="card mb-3">
   <div class="card-header d-flex align-items-center justify-content-between">
-    <button class="btn" on:click={() => folded = !folded}>
+    <button class="btn p-0" on:click={() => folded = !folded}>
       <h5>{ path }</h5>
     </button>
     <a href="{ url }">Raw content</a>
   </div>
-    {#if !folded}
-      <div class="card-body">
-      {#await getRawFile()}
-        <SyncLoader />
-      {:then}
-        {#if data == null}
-          Content too large, show <a href="{ url }">raw content</a>.
-        {:else}
-          <pre>{ data }</pre>
-        {/if}
-      {/await}
+  {#if !folded}
+    <div class="card-body">
+    {#await getRawFile()}
+      <SyncLoader />
+    {:then}
+      {#if data == null}
+        Content too large, show <a href="{ url }">raw content</a>.
+      {:else}
+        <pre>{ data }</pre>
+      {/if}
+    {/await}
     </div>
   {/if}
 </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -47,6 +47,7 @@ import PipelineStatus from './PipelineStatus.svelte'
 import {safeMarkdown} from './markdown.js'
 import CtrlP from './CtrlP.svelte'
 import ColorTheme from "./ColorTheme.svelte"
+import TestFile from "./TestFile.svelte"
 
 class ReplaceHtmlElement extends HTMLElement {
 	constructor() {
@@ -108,6 +109,7 @@ createElement('upload-solution', UploadSolution);
 createElement('pipeline-status', PipelineStatus);
 createElement('ctrlp', CtrlP);
 createElement("color-theme", ColorTheme);
+createElement('test-file', TestFile);
 
 function focusTab() {
 	const hash = document.location.hash.replace('#', '').split('-')[0].split(';')[0];

--- a/templates/web/task_detail.html
+++ b/templates/web/task_detail.html
@@ -204,21 +204,7 @@
                 {% endif %}
 
                 {% for path, file in input.sorted_files %}
-                <div class="card mb-3">
-                    <div class="card-header">
-                        <h5>
-                          {{ path }}
-                          (<a href="{% url 'raw_test_content' task.code input.name path %}{% if submit %}?student={{submit.student}}{%endif%}">Raw content</a>)
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        {% if file.size < max_inline_content_bytes or not max_inline_content_bytes %}
-                        <pre>{{ file.read }}</pre>
-                        {% else %}
-                            Content too large, show <a href='{% url 'raw_test_content' task.code input.name path %}'>raw content</a>.
-                        {% endif %}
-                    </div>
-                </div>
+                <kelvin-test-file url="{% url 'raw_test_content' task.code input.name path %}" path="{{ path }}"></kelvin-test-file>
                 {% endfor %}
 
                 {% endfor %}

--- a/templates/web/task_detail.html
+++ b/templates/web/task_detail.html
@@ -204,7 +204,7 @@
                 {% endif %}
 
                 {% for path, file in input.sorted_files %}
-                <kelvin-test-file url="{% url 'raw_test_content' task.code input.name path %}" path="{{ path }}"></kelvin-test-file>
+                <kelvin-test-file url="{% url 'raw_test_content' task.code input.name path %}{% if submit %}?student={{ submit.student }}{% endif %}" path="{{ path }}" max-bytes="{{ max_inline_content_bytes }}"></kelvin-test-file>
                 {% endfor %}
 
                 {% endfor %}


### PR DESCRIPTION
Closes #397.
Test files are hidden by default and should be opened manually. The file contents is loaded after the first "unfold" of a card.