### PR TITLE
Make student view available for teachers

### DIFF
--- a/templates/web/layout.html
+++ b/templates/web/layout.html
@@ -52,11 +52,14 @@
                 <li class="nav-item"><a class="nav-link" href="{% url 'submits' %}">Submits</a></li>
                 <li class="nav-item"><a class="nav-link" href="{% url 'tasks' %}">Tasks</a></li>
                 {% endif %}
-                {% if is_teacher and user.is_staff %}
+                {% if is_teacher %}
+                <li class="nav-item"><a class="nav-link" href="{% url 'student_index' %}">Student view</a></li>
+                {% if user.is_staff %}
                 {% comment %}
                 https://stackoverflow.com/questions/694477/getting-django-admin-url-for-an-objects
                 {% endcomment %}
                 <li class="nav-item"><a class="nav-link" href="{% url 'admin:index' %}">Admin</a></li>
+                {% endif %}
                 {% endif %}
               </ul>
               <ul class="navbar-nav">

--- a/web/urls.py
+++ b/web/urls.py
@@ -9,6 +9,7 @@ from .views import statistics as statistics_view
 
 urlpatterns = [
     path('', common_view.index, name='index'),
+    path('student-view', student_view.student_index, name='student_index'),
 
     path('find-task/<int:task_id>/<str:login>/', student_view.find_task_detail, name='find_task_detail'),
     path('task/<int:assignment_id>/<str:login>/', student_view.task_detail, name='task_detail'),


### PR DESCRIPTION
I propose few changes that aim to make the following possible:

- Teachers, who are also assigned as students in other classes, can now navigate to their _student view_ and therefore access such classes
- When making requests to class related API urls, the server will now return classes where the current user is teacher **or student** (while keeping this endpoint restricted to teachers only)

Let me know whether there are any further changes necessary. Thanks :)