### PR TITLE
[Bump] Sync Python packages with ones on production

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4==4.11.1
 bokeh==2.3.2
-cssselect
+cssselect==1.1.0
 django-cas-ng==4.2.1
-django-notifications-hq
+django-notifications-hq==1.6.0
 django-redis-cache==2.1.1
 django-rq==2.3.2
 django-webpush==0.3.2
@@ -12,14 +12,14 @@ Jinja2==2.11.3
 MarkupSafe==2.0.1
 mosspy==1.0.9
 networkx==2.5
-numpy==1.24.1
+numpy==1.26.4
 oauthlib==3.2.2
 pandas==1.5.3
-psycopg2
+psycopg2==2.9.9
 pygraphviz==1.7
 pyserde==0.13.1
 python-magic==0.4.27
-pyyaml==5.4
+pyyaml==6.0.1
 readwise-django-rq-scheduler==1.2.1
 redis==3.5.3
 requests==2.31.0
@@ -27,6 +27,6 @@ requests_oauthlib==1.3.1
 rq==1.9.0
 rq-scheduler==0.11.0
 six==1.16.0
-typing-extensions==4.7.1
+typing-extensions==4.9.0
 Unidecode==1.3.6
 


### PR DESCRIPTION
Sync of Python packages that are currently installed on production site that runs Python 3.12.

And yes, I know we need to use `pip-tools` or something similar (#405).