### PR TITLE
Fix dark bg color of quick point assignment overlay

### DIFF
--- a/frontend/src/AssignmentPoints.svelte
+++ b/frontend/src/AssignmentPoints.svelte
@@ -55,7 +55,7 @@
             position: fixed;
             top: 0;
             left: 0;
-            background: rgba(255, 255, 255, 0.9);
+            background: rgba(var(--bs-body-bg-rgb), 0.9);
             width: 100vw;
             height: 100vh;
             z-index: 11;


### PR DESCRIPTION
I discovered this hard coded color code for quick point assignment overlay background (mobile feature). With this change it should always pull the correct color for light/dark mode right from Bootstrap, guaranteeing legibility.

Before (dark mode) |  After (dark mode)
:---------------------------:|:---------------------------:
![dark-mode-before](https://github.com/mrlvsb/kelvin/assets/4291478/97f4a440-16b0-467c-acf7-684c67100edc)  |  ![dark-mode-after](https://github.com/mrlvsb/kelvin/assets/4291478/573c1795-e606-4cca-b760-c6ba1570805e)


