### PR TITLE
Add missing import in tests script

### DIFF
--- a/web/views/assets/run-tests.py
+++ b/web/views/assets/run-tests.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import Optional, List
 
 # Usage: python3 run-tests.py <path-to-binary>
 # Example: python3 run-tests.py ./main


### PR DESCRIPTION
A few students reported that there's an error in `run-tests.py` script. I've added missing import of `Optional` to make it working. Tested on Python 3.12.1.