### PR TITLE
Pyright virtual environment config

### DIFF
--- a/.github/workflows/pyright-venv.yml
+++ b/.github/workflows/pyright-venv.yml
@@ -1,0 +1,22 @@
+name: Pyright in virtual environment
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  pyright:
+    name: pyright
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: |
+          sudo apt-get install libgraphviz-dev
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - uses: jakebailey/pyright-action@v2


### PR DESCRIPTION
At this pyright check fails on building dependencies. Also, building pandas `1.5.3` in the workflow takes a long time. We can upgrade it to `2.x` and speedup the process. I'll take a look at it.