### PR TITLE
Set site language

### DIFF
--- a/templates/web/layout.html
+++ b/templates/web/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-us">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         {% if sentry_url %}


### PR DESCRIPTION
I am frustrated by prompts of my web browser thinking that Kelvin is in Danish language, that's why I added a `lang` attribute to `html` tag so it is clear for browsers.