### PR TITLE
[Fix] SemesterId in INBUs API

### DIFF
--- a/common/inbus/inbus.py
+++ b/common/inbus/inbus.py
@@ -95,7 +95,7 @@ def schedule_subject_by_version_id(
     """
     url = urllib.parse.urljoin(config.INBUS_SERVICE_EDISON_URL, "schedule")
     concrete_activities_resp = utils.inbus_request(
-        url, {"subjectVersionId": subject_version_id, "semesterId": 129}
+        url, {"subjectVersionId": subject_version_id, "semesterId": 126}
     )
 
     concrete_activities = []


### PR DESCRIPTION
This has to be elaborated on more thoughly in future. Prefarably syncing Kelvin semester with INBUS's ones in frontend selection. But it also waits for the new frondend implementation.