### PR TITLE
Improve parsing of Markdown lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "lxml==5.1.0",
     "markdown>=3.7",
     "MarkupSafe==2.0.1",
+    "mdx-truly-sane-lists>=1.3",
     "mosspy==1.0.9",
     "networkx==2.5",
     "numpy==1.26.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,6 +145,9 @@ markdown==3.7 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
 markupsafe==2.0.1 \
     --hash=sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a
+mdx-truly-sane-lists==1.3 \
+    --hash=sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45 \
+    --hash=sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37
 mosspy==1.0.9 \
     --hash=sha256:7ebae3fc2e84f70a80796fee640fd933511e9da9b5e15920e60e298bb9a785ad
 mypy-extensions==1.0.0 \

--- a/uv.lock
+++ b/uv.lock
@@ -393,6 +393,7 @@ dependencies = [
     { name = "lxml" },
     { name = "markdown" },
     { name = "markupsafe" },
+    { name = "mdx-truly-sane-lists" },
     { name = "mosspy" },
     { name = "networkx" },
     { name = "numpy" },
@@ -435,6 +436,7 @@ requires-dist = [
     { name = "lxml", specifier = "==5.1.0" },
     { name = "markdown", specifier = ">=3.7" },
     { name = "markupsafe", specifier = "==2.0.1" },
+    { name = "mdx-truly-sane-lists", specifier = ">=1.3" },
     { name = "mosspy", specifier = "==1.0.9" },
     { name = "networkx", specifier = "==2.5" },
     { name = "numpy", specifier = "==1.26.4" },
@@ -490,6 +492,18 @@ name = "markupsafe"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a", size = 18596 }
+
+[[package]]
+name = "mdx-truly-sane-lists"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/27/16456314311abac2cedef4527679924e80ac4de19dd926699c1b261e0b9b/mdx_truly_sane_lists-1.3.tar.gz", hash = "sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45", size = 5359 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/9e/dcd1027f7fd193aed152e01c6651a197c36b858f2cd1425ad04cb31a34fc/mdx_truly_sane_lists-1.3-py3-none-any.whl", hash = "sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37", size = 6071 },
+]
 
 [[package]]
 name = "mosspy"

--- a/web/task_utils.py
+++ b/web/task_utils.py
@@ -49,6 +49,9 @@ def markdown_to_html(input: str) -> str:
             "fenced_code",
             # Enable parsing Markdown inside HTML tags (<div markdown="1">)
             "md_in_html",
+            # Better list handling
+            # Allows nested indents to be just 2 spaces
+            "mdx_truly_sane_lists",
         ],
     )
 


### PR DESCRIPTION
Restores original `pandoc` behavior that allowed sublists to be indented with just 2 (and not 4) spaces.