### PR TITLE
Disable Docker cache writes for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           cache-from: type=registry,ref=ghcr.io/mrlvsb/kelvin-ci-cache
-          cache-to: type=registry,ref=ghcr.io/mrlvsb/kelvin-ci-cache,compression=zstd
+          # Only write the cache in a merge build
+          # https://github.com/docker/build-push-action/issues/845#issuecomment-1512619265
+          cache-to: ${{ github.event_name == 'merge_group' && 'type=registry,ref=ghcr.io/mrlvsb/kelvin-ci-cache,compression=zstd' || '' }}
           tags: ghcr.io/mrlvsb/kelvin:latest,ghcr.io/mrlvsb/kelvin:${{ github.sha }}
           outputs: type=docker,dest=${{ runner.temp }}/kelvin.tar
       - name: Share built image


### PR DESCRIPTION
PRs from forks don't have the necessary permissions to write to the build cache.

Fixes: https://github.com/mrlvsb/kelvin/issues/584