### PR TITLE
Make logging configuration consistent and remove file logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,6 @@ KELVIN__TASKS_PATH=./tasks
 KELVIN__SUBMITS_PATH=./submits
 # Path where submit results will be stored
 KELVIN__SUBMIT_RESULTS_PATH=./submit_results
-# Path to file logging
-KELVIN__LOGFILE_PATH=./kelvin_app.log
 
 ### Postgres
 DATABASE__HOST=127.0.0.1

--- a/kelvin/settings.py
+++ b/kelvin/settings.py
@@ -222,40 +222,37 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "{asctime} - {levelname} - {message}",
+            "format": "{asctime} [{levelname}] ({name}:{pathname}:{lineno}) {message}",
+            "style": "{",
+        },
+        "http": {
+            "format": "{asctime} [{levelname}] {message}",
             "style": "{",
         },
     },
     "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-        },
+        "console": {"class": "logging.StreamHandler", "formatter": "verbose"},
+        "console_http": {"class": "logging.StreamHandler", "formatter": "http"},
         "mail_admins": {
             "level": "ERROR",
             "class": "django.utils.log.AdminEmailHandler",
-        },
-        "file": {
-            "level": "INFO",
-            "class": "logging.FileHandler",
-            "filename": os.getenv("KELVIN__LOGFILE_PATH", "./kelvin_app.log"),
+            "formatter": "verbose",
         },
     },
     "loggers": {
-        "django": {
-            "handlers": ["console", "mail_admins", "file"],
-            "level": "ERROR",
-            "propagate": True,
-        },
-        "evaluator": {
+        # Default logger for everything
+        "": {
             "handlers": ["console", "mail_admins"],
             "level": "DEBUG",
-            "propagate": True,
         },
-        "user_logins": {  # Custom logger for user login events
-            "handlers": ["file"],
-            "level": "INFO",
+        # Override format of default Django logs
+        "django.server": {
+            "handlers": ["console_http"],
+            "level": "DEBUG",
             "propagate": False,
         },
+        # Disable logs from the serde crate, to avoid spam
+        "serde": {"handlers": [], "level": "DEBUG", "propagate": False},
     },
 }
 


### PR DESCRIPTION
Before, we were using a weird combination of the default Django settings and some overridden values.

Now, all logs are written to the console by default, and the format of Django and app logs is unified.