### PR TITLE
Fix invalid keys of Clang-Tidy checks

### DIFF
--- a/evaluator/images/clang-tidy/build_urls.py
+++ b/evaluator/images/clang-tidy/build_urls.py
@@ -33,8 +33,8 @@ def process(check: str) -> Tuple[str, Optional[str]]:
     else:
         matched = check.split("-", 1)
     baseurl += f"{matched.pop(0)}/"
-    check = matched.pop(0)
-    url = f"{baseurl}{check}.html"
+    short_check = matched.pop(0)
+    url = f"{baseurl}{short_check}.html"
     page = get(url)
 
     if page:


### PR DESCRIPTION
This is a hotfix to have correct Clang-Tidy checks identifiers in the JSON of URLs. Image rebuild required.

CC @Kobzol