### PR TITLE
Base components and business logic for quizzes

### DIFF
--- a/api/dto.py
+++ b/api/dto.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+from serde import serde, field, Strict
+
+
+# Class that represents a DTO for single answer in a question.
+@serde(type_check=Strict)
+class AnswerDto:
+    # Content of answer
+    answer_content: str
+    # Indicator if answer is correct
+    is_correct: bool
+    # Identifier of answer
+    _id: str | None = field(default=None, skip_if=lambda x: x is None)
+
+    # Positive and negative fields are required when question type is abcd.multiple
+    # Value that is added to accumulator if the answer is not marked wrong
+    positive: int | None = field(default=None, skip_if=lambda x: x is None)
+    # Value that is subtracted from accumulator if the answer is marked wrong
+    negative: int | None = field(default=None, skip_if=lambda x: x is None)
+
+    @property
+    def id(self):
+        return self._id
+
+
+# Class that represents a DTO for a question in a quiz.
+@serde(type_check=Strict)
+class QuestionDto:
+    # Content of quiz question
+    content: str
+    # Points of question
+    points: int
+    # Name of question
+    name: str
+    # Type of question (open, abcd, abcd.multiple)
+    type: str
+    # Identifier of question
+    _id: str | None = field(default=None, skip_if=lambda x: x is None)
+    # Answers of question
+    answers: list[AnswerDto] | None = field(default=None, skip_if=lambda x: x is None)
+
+    @property
+    def id(self):
+        return self._id
+
+
+# Class that represents a DTO for a quiz.
+@serde(type_check=Strict)
+class QuizDto:
+    # List of quiz questions
+    questions: list[QuestionDto]
+    # Indicator if questions will be shuffled when generating quiz
+    shuffle: bool | None = field(default=None, skip_if=lambda x: x is None)
+
+
+@serde(type_check=Strict)
+class QuizCreateDto:
+    # abbr of subject quiz is linked to
+    subject: str
+    # name of quiz
+    name: str
+
+
+# Class that represents a DTO to update a quiz.
+@serde(type_check=Strict)
+class UpdateQuizDto:
+    # Working relative directory of quiz
+    quiz_directory: str
+    # Indicator if questions will be shuffled when generating quiz
+    shuffle: bool
+    # List of quiz questions
+    questions: list[QuestionDto] | None = field(default=None, skip_if=lambda x: x is None)
+
+
+# Class that represents a DTO to update an assignment
+@serde(type_check=Strict)
+class QuizClassAssignmentUpdateDto:
+    # ID of class quiz should be assigned to
+    id: int
+    # Indicator if quiz results are published
+    publish_results: bool | None = False
+    # Duration of quiz (in minutes)
+    duration: int | None = None
+    # Deadline of quiz
+    deadline: datetime | None = field(
+        default=None, deserializer=lambda x: datetime.fromisoformat(x)
+    )
+    # Start time of quiz
+    assigned: datetime | None = field(
+        default=None, deserializer=lambda x: datetime.fromisoformat(x)
+    )
+    # ID of assignment
+    assigned_id: int | None = None
+
+
+# Class that represents a DTO to update an assignments
+@serde(type_check=Strict)
+class QuizClassAssignmentsUpdateDto:
+    # List of possible assignments
+    assignments: list[QuizClassAssignmentUpdateDto]
+
+
+# Class that represents score for a question
+@serde(type_check=Strict)
+class ScoreDto:
+    # Assigned points
+    points: int | float
+    # Assigned comment
+    comment: str = ""
+
+
+# Class that represents scoring for a quiz questions
+@serde(type_check=Strict)
+class ScoringDto:
+    # Dict of scores, key is ID of question
+    scoring: dict[str, ScoreDto]
+
+
+# Class that represents submitted answer
+@serde(type_check=Strict)
+class SubmitAnswerDto:
+    # Answer, which can be text or boolean value
+    answer: bool | str
+    # ID of answer of question in case of possible multiple answers
+    id: str | None = field(default=None, skip_if=lambda x: x is None)
+
+
+# Class that represents submitted answers
+@serde(type_check=Strict)
+class SubmitAnswersDto:
+    # List of submitted answers, key is ID of question
+    submit: dict[str, list[SubmitAnswerDto]]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,28 +1,29 @@
 from django.urls import path
 
-from . import views
+from .views import default as default_view
+from .views import quiz as quiz_view
 from common.inbus import views as inbus_views
 
 urlpatterns = [
-    path("tasks/<int:task_id>", views.task_detail),
-    path("tasks/<int:task_id>/duplicate", views.duplicate_task),
-    path("tasks/", views.task_detail),
-    path("task-list", views.tasks_list_all),
-    path("task-list/<subject_abbr>", views.tasks_list_all),
-    path("student-list", views.student_list),
-    path("submits/<int:task_assignment>", views.create_submit),
-    path("info", views.info),
-    path("classes", views.class_detail_list),
-    path("classes/all", views.all_classes),
-    path("classes/<int:class_id>/add_students", views.add_student_to_class),
-    path("subject/<subject_abbr>", views.subject_list),
-    path("subjects/all", views.subjects_all),
-    path("teachers/all", views.teachers_all),
-    path("reevaluate_task/<int:task_id>", views.reevaluate_task),
-    path("search", views.search),
-    path("transfer_students", views.transfer_students),
-    path("semesters", views.semesters),
-    path("import/activities", views.import_activities),
+    path("tasks/<int:task_id>", default_view.task_detail),
+    path("tasks/<int:task_id>/duplicate", default_view.duplicate_task),
+    path("tasks/", default_view.task_detail),
+    path("task-list", default_view.tasks_list_all),
+    path("task-list/<subject_abbr>", default_view.tasks_list_all),
+    path("student-list", default_view.student_list),
+    path("submits/<int:task_assignment>", default_view.create_submit),
+    path("info", default_view.info),
+    path("classes", default_view.class_detail_list),
+    path("classes/all", default_view.all_classes),
+    path("classes/<int:class_id>/add_students", default_view.add_student_to_class),
+    path("subject/<subject_abbr>", default_view.subject_list),
+    path("subjects/all", default_view.subjects_all),
+    path("teachers/all", default_view.teachers_all),
+    path("reevaluate_task/<int:task_id>", default_view.reevaluate_task),
+    path("search", default_view.search),
+    path("transfer_students", default_view.transfer_students),
+    path("semesters", default_view.semesters),
+    path("import/activities", default_view.import_activities),
     path("inbus/subject_versions", inbus_views.subject_versions),
     path(
         "inbus/schedule/subject/version/<int:subject_version_id>/<int:inbus_semester_id>",
@@ -32,4 +33,20 @@ urlpatterns = [
         "inbus/schedule/students/activity/<int:concrete_activity_id>",
         inbus_views.students_in_concrete_activity,
     ),
+    path("quiz/<int:quiz_id>", quiz_view.quiz_yaml, name="api_quiz_yaml"),
+    path(
+        "quiz/<int:quiz_id>/question/preview",
+        quiz_view.quiz_question_preview,
+        name="api_quiz_question_preview",
+    ),
+    path(
+        "quiz/<int:enrolled_id>/result/<int:is_submit>",
+        quiz_view.quiz_results,
+        name="api_quiz_results",
+    ),
+    path("quiz/<int:enrolled_id>/scoring", quiz_view.quiz_scoring, name="api_quiz_scoring"),
+    path("quiz/<int:quiz_id>/classes", quiz_view.quiz_classes, name="api_quiz_classes"),
+    path("quiz/add", quiz_view.quiz_add, name="api_quiz_add"),
+    path("quiz/<int:quiz_id>/duplicate", quiz_view.quiz_duplicate),
+    path("quiz/<int:quiz_id>/assignments", quiz_view.quiz_assignments, name="api_quiz_assignments"),
 ]

--- a/api/views/default.py
+++ b/api/views/default.py
@@ -16,7 +16,10 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.models import User
 from django.db.models import QuerySet, Q
-from django.http import HttpRequest, HttpResponseBadRequest
+from django.http import (
+    HttpRequest,
+    HttpResponseBadRequest,
+)
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, resolve_url
 from django.urls import reverse

--- a/api/views/quiz.py
+++ b/api/views/quiz.py
@@ -1,0 +1,319 @@
+import errno
+import json
+import os
+import re
+from shutil import copytree, rmtree, ignore_patterns
+
+from django.utils import timezone
+from serde.json import from_json, to_json
+from serde.yaml import to_yaml
+from unidecode import unidecode
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth.models import User
+from django.http import (
+    HttpRequest,
+    HttpResponseForbidden,
+)
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+
+from common.models import Subject
+from common.utils import is_teacher
+from api.dto import (
+    QuizDto,
+    UpdateQuizDto,
+    QuizCreateDto,
+    QuizClassAssignmentsUpdateDto,
+    ScoringDto,
+    SubmitAnswersDto,
+)
+from quiz.models import Quiz, AssignedQuiz, EnrolledQuiz
+from quiz.quiz_utils import score_quiz, quiz_assigned_classes
+from quiz.settings import QUIZ_PATH
+from web.markdown_utils import process_markdown
+from .utils import MethodNotImplemented
+
+
+# Function that gets, updates, or delete quiz and its content.
+@user_passes_test(is_teacher)
+def quiz_yaml(request: HttpRequest, quiz_id: int):
+    quiz = get_object_or_404(Quiz, pk=quiz_id)
+
+    if request.method == "GET":
+        return quiz_yaml_get(request, quiz)
+    if request.method == "POST":
+        return quiz_yaml_post(request, quiz)
+    elif request.method == "DELETE":
+        return quiz_yaml_delete(request, quiz)
+
+    return MethodNotImplemented()
+
+
+# Function to get quiz yaml content
+def quiz_yaml_get(request: HttpRequest, quiz: Quiz):
+    return JsonResponse({"yaml": quiz.read()})
+
+
+# Function to create/update quiz
+def quiz_yaml_post(request: HttpRequest, quiz: Quiz):
+    update_quiz = from_json(UpdateQuizDto, json.loads(request.body.decode("utf-8")))
+
+    if os.path.normpath(update_quiz.quiz_directory) != os.path.normpath(quiz.src):
+        try:
+            quiz.set_up_directory(update_quiz.quiz_directory)
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                return JsonResponse({"error": "Directory is used by another quiz."}, status=409)
+            raise
+
+    quiz_dto = QuizDto(shuffle=update_quiz.shuffle, questions=update_quiz.questions)
+
+    quiz.write(to_yaml(quiz_dto, allow_unicode=True))
+
+    return JsonResponse({"yaml": quiz.read()})
+
+
+# Function to delete quiz
+def quiz_yaml_delete(request: HttpRequest, quiz: Quiz):
+    if quiz.assignedquiz_set.count() == 0:
+        quiz.delete()
+        rmtree(quiz.get_directory_path())
+        return JsonResponse({"redirect": "/"})
+    else:
+        return JsonResponse({"error": "Quiz has assignments and cannot be deleted."}, status=409)
+
+
+# Function that stores student answers for enrolled quiz.
+@login_required
+def quiz_results(request: HttpRequest, enrolled_id: int, is_submit: int):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    enrolled_quiz = get_object_or_404(EnrolledQuiz, pk=enrolled_id)
+
+    if request.user.id != enrolled_quiz.student.id:
+        return HttpResponseForbidden()
+
+    if enrolled_quiz.submitted:
+        return HttpResponseForbidden()
+
+    submit_answers_dto = from_json(SubmitAnswersDto, request.body.decode("utf-8"))
+
+    enrolled_quiz.submit = json.loads(to_json(submit_answers_dto.submit))
+
+    if is_submit:
+        enrolled_quiz.submitted = True
+        enrolled_quiz.submitted_at = timezone.now()
+        score_quiz(enrolled_quiz)
+        return JsonResponse({"redirect": "/"})
+
+    enrolled_quiz.save()
+
+    return JsonResponse({"message": "Answers have been saved."})
+
+
+# Function that stores quiz scoring.
+@user_passes_test(is_teacher)
+def quiz_scoring(request: HttpRequest, enrolled_id: int):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    enrolled_quiz = get_object_or_404(EnrolledQuiz, pk=enrolled_id)
+
+    scoring_dto = from_json(ScoringDto, request.body.decode("utf-8"))
+
+    teacher = request.user
+
+    if enrolled_quiz.scored_by is None:
+        enrolled_quiz.scored_by = teacher
+    elif enrolled_quiz.scored_by.id != teacher.id:
+        return HttpResponseForbidden()
+
+    enrolled_quiz.scoring = json.loads(to_json(scoring_dto.scoring))
+
+    enrolled_quiz.save()
+
+    return JsonResponse({"message": "Scoring has been updated."})
+
+
+# Function to assign or remove quizzes from classes.
+@user_passes_test(is_teacher)
+def quiz_assignments(request: HttpRequest, quiz_id: int):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    quiz = get_object_or_404(Quiz, pk=quiz_id)
+
+    update_assignments = from_json(QuizClassAssignmentsUpdateDto, request.body.decode("utf-8"))
+
+    for assignment in update_assignments.assignments:
+        if (
+            assignment.assigned is not None
+            and assignment.deadline is not None
+            and assignment.duration is not None
+        ):
+            # If assignment already exist, update it.
+            # Otherwise, create new assignment.
+            if assignment.assigned_id is not None:
+                assigned_quiz = AssignedQuiz.objects.get(pk=assignment.assigned_id)
+
+                assigned_quiz.deadline = assignment.deadline
+                assigned_quiz.assigned = assignment.assigned
+                assigned_quiz.duration = assignment.duration
+                assigned_quiz.publish_results = assignment.publish_results
+            else:
+                assigned_quiz = AssignedQuiz.objects.create(
+                    clazz_id=assignment.id,
+                    quiz_id=quiz.pk,
+                    deadline=assignment.deadline,
+                    assigned=assignment.assigned,
+                    duration=assignment.duration,
+                    publish_results=assignment.publish_results,
+                )
+
+            assigned_quiz.save()
+        else:
+            # If the assignment is not complete, it will be deleted if possible.
+            if assignment.assigned_id is not None:
+                try:
+                    assigned_quiz = AssignedQuiz.objects.get(pk=assignment.assigned_id)
+
+                    if assigned_quiz.enrolledquiz_set.count() == 0:
+                        assigned_quiz.delete()
+                except AssignedQuiz.DoesNotExist:
+                    pass
+
+    return JsonResponse(
+        {
+            "message": "Assignments have been updated.",
+            "assignments": quiz_assigned_classes(quiz, request.user.id),
+            "quiz_deletable": quiz.assignedquiz_set.count() == 0,
+        }
+    )
+
+
+# Function that convert markdown question to HTML and then returns it.
+@user_passes_test(is_teacher)
+def quiz_question_preview(request: HttpRequest, quiz_id: int):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    quiz = get_object_or_404(Quiz, pk=quiz_id)
+
+    content = json.loads(request.body.decode("utf-8"))
+
+    markdown = process_markdown(quiz.src, content, "quiz")
+
+    return JsonResponse({"html": markdown.content})
+
+
+# Function that returns the list of all classes quiz is assigned to.
+@user_passes_test(is_teacher)
+def quiz_classes(request: HttpRequest, quiz_id: int):
+    if request.method != "GET":
+        return MethodNotImplemented()
+
+    assignments = AssignedQuiz.objects.filter(quiz=quiz_id)
+
+    classes_dto = []
+
+    for assignment in assignments:
+        classes_dto.append(
+            {
+                "classId": assignment.clazz.id,
+                "className": str(assignment.clazz),
+            }
+        )
+
+    return JsonResponse({"classes": classes_dto})
+
+
+# Function that creates a new quiz.
+@user_passes_test(is_teacher)
+def quiz_add(request: HttpRequest):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    quiz_create = from_json(QuizCreateDto, request.body.decode("utf-8"))
+
+    subject = Subject.objects.get(abbr=quiz_create.subject)
+
+    abbr = subject.abbr.upper()
+    username = request.user.username.upper()
+    dir_name = unidecode(quiz_create.name).replace(" ", "_").upper()
+
+    src = os.path.join(QUIZ_PATH, abbr, username)
+
+    postfix = 1
+
+    # Finding a working directory for new quiz, working directory is considered found if generated path doesn't point to
+    # existing directory and there is no quiz that have generated path assigned.
+    while True:
+        # Assign postfix _X to potential new working directory, where X is natural number
+        postfix_dir_name = dir_name + "_" + str(postfix)
+        postfix_src = os.path.join(src, postfix_dir_name)
+
+        count = Quiz.objects.filter(src=postfix_src).count()
+
+        if count == 0:
+            try:
+                os.makedirs(postfix_src)
+
+                break
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+
+        postfix += 1
+
+    quiz = Quiz.objects.create(
+        name=quiz_create.name, subject=subject, src=os.path.join(abbr, username, postfix_dir_name)
+    )
+
+    quiz.save()
+
+    with open(quiz.get_identifier_path(), "w", encoding="utf-8") as file:
+        file.write(str(quiz.pk))
+
+    quiz.write("questions:\n")
+
+    return JsonResponse({"message": "Quiz successfully added."})
+
+
+# Function that create a duplicate of the quiz.
+@user_passes_test(is_teacher)
+def quiz_duplicate(request, quiz_id):
+    if request.method != "POST":
+        return MethodNotImplemented()
+
+    quiz = get_object_or_404(Quiz, pk=quiz_id)
+    new_src = quiz.src
+
+    for user in User.objects.filter(groups__name="teachers"):
+        new_src = new_src.replace(user.username, request.user.username)
+
+    i = 1
+
+    # Finding a working directory for duplicate of quiz, working directory is considered found if generated path doesn't
+    # point to existing directory and there is no quiz that have generated path assigned.
+    while True:
+        # Assign postfix _copy_X to potential new working directory, where X is natural number
+        new_src = re.sub(r"(_copy_[0-9]+$|$)", f"_copy_{i}", new_src, count=1)
+        count = Quiz.objects.filter(src=new_src).count()
+        if count == 0 and not os.path.exists(os.path.join(QUIZ_PATH, new_src)):
+            break
+        i += 1
+
+    new_path = os.path.join(QUIZ_PATH, new_src)
+    copytree(quiz.get_directory_path(), new_path, ignore=ignore_patterns(".quiz_id"))
+
+    quiz_copy = quiz
+    quiz_copy.pk = None
+    quiz_copy.src = new_src
+    quiz_copy.save()
+
+    with open(quiz_copy.get_identifier_path(), "w", encoding="utf-8") as file:
+        file.write(str(quiz_copy.pk))
+
+    return JsonResponse({"id": quiz_copy.pk})

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,0 +1,5 @@
+from django.http import JsonResponse
+
+
+def MethodNotImplemented():
+    return JsonResponse({"error": "Method is not implemented."}, status=501)

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -1,5 +1,13 @@
+import os
+import errno
+from shutil import copytree, rmtree
+
 from django.db import models
+from serde.yaml import from_yaml
 from common.models import Class, Subject, User
+from api.dto import QuizDto
+
+from quiz.settings import QUIZ_PATH
 
 
 # Model that represents a quiz
@@ -12,6 +20,44 @@ class Quiz(models.Model):
 
     def __str__(self):
         return self.name
+
+    # Method that writes content to the quiz file.
+    def write(self, yaml_content: str):
+        with open(self.get_file_path(), "w", encoding="utf-8") as file:
+            file.write(yaml_content)
+
+    # Method that reads content from the quiz file.
+    def read(self):
+        with open(self.get_file_path(), "r", encoding="utf-8") as file:
+            return file.read()
+
+    # Method that returns the directory path of the quiz.
+    def get_directory_path(self):
+        return os.path.join(QUIZ_PATH, self.src)
+
+    # Method that returns the file path of the quiz.
+    def get_file_path(self):
+        return os.path.join(self.get_directory_path(), "quiz.yml")
+
+    # Method that returns the identifier file path of the quiz.
+    def get_identifier_path(self):
+        return os.path.join(self.get_directory_path(), ".quiz_id")
+
+    # Method that returns a DTO of the quiz
+    def get_dto(self):
+        return from_yaml(QuizDto, self.read())
+
+    # Method that tries to set up the new directory for the quiz
+    def set_up_directory(self, new_src: str):
+        copytree(os.path.join(QUIZ_PATH, self.src), os.path.join(QUIZ_PATH, new_src))
+
+        old_src = self.src
+
+        self.src = new_src
+
+        self.save()
+
+        rmtree(os.path.join(QUIZ_PATH, old_src))
 
     class Meta:
         verbose_name_plural = "Quizzes"
@@ -68,5 +114,14 @@ class EnrolledQuiz(models.Model):
     def __str__(self):
         return f"{self.assigned_quiz.quiz.name} {self.student} {self.id}"
 
+    # Method that sums assigned scores of questions and returns the total score of the quiz.
+    def score(self):
+        score = 0.0
+        for key in self.scoring:
+            score += float(self.scoring[key]["points"])
+        return score
+
     class Meta:
         verbose_name_plural = "Enrolled quizzes"
+
+

--- a/quiz/quiz_utils.py
+++ b/quiz/quiz_utils.py
@@ -1,0 +1,136 @@
+from django.contrib.auth.models import User
+
+from common.models import Class
+from quiz.models import Quiz, AssignedQuiz, EnrolledQuiz
+from web.markdown_utils import process_markdown
+
+
+# Exception that can be raised during invalid quiz operations
+class QuizException(Exception):
+    pass
+
+
+# Function that returns a list of classes that are/can be assigned to the quiz.
+def quiz_assigned_classes(quiz: Quiz, requested_by: int):
+    classes = Class.objects.current_semester().filter(subject=quiz.subject)
+    user = User.objects.get(pk=requested_by)
+
+    assignments_dtos = []
+
+    for clazz in classes:
+        assignment = AssignedQuiz.objects.filter(quiz=quiz.id, clazz=clazz.id)
+        if assignment.count() == 0:
+            assignments_dtos.append(
+                {
+                    "id": clazz.id,
+                    "name": str(clazz),
+                    "code": clazz.code,
+                    "teacher": clazz.teacher.username,
+                    "timeslot": clazz.timeslot,
+                    "visible": clazz.teacher.id == user.id,
+                    "deletable": True,
+                }
+            )
+        elif assignment.count() == 1:
+            assignment = assignment[0]
+            deletable = assignment.enrolledquiz_set.count() == 0
+
+            assignments_dtos.append(
+                {
+                    "id": clazz.id,
+                    "name": str(clazz),
+                    "assigned_id": assignment.id,
+                    "assigned": str(assignment.assigned),
+                    "deadline": str(assignment.deadline),
+                    "duration": assignment.duration,
+                    "code": clazz.code,
+                    "timeslot": clazz.timeslot,
+                    "teacher": clazz.teacher.username,
+                    "publish_results": assignment.publish_results,
+                    "visible": clazz.teacher.id == user.id,
+                    "deletable": deletable,
+                }
+            )
+        else:
+            raise Exception("Multiple assignments for one class")
+
+    assignments_dtos.sort(
+        key=lambda x: (x["teacher"] != user.username, x["teacher"], "assigned" not in x)
+    )
+
+    return assignments_dtos
+
+
+# Method that computes the score of a submitted quiz for questions that are possible to score automatically.
+# Automatically scored questions are of type: abcd, abcd.multiple
+def score_quiz(enrolled_quiz: EnrolledQuiz):
+    if not enrolled_quiz.submitted:
+        raise QuizException("Attempt to score non submitted quiz.")
+    template = enrolled_quiz.template.content
+    submit = enrolled_quiz.submit
+    scoring = {}
+    questions = template.get("questions")
+
+    if questions is not None:
+        for question in questions:
+            scoring[question["_id"]] = {"points": 0.0, "comment": ""}
+            submit_answers = submit.get(question["_id"])
+            if submit_answers is None:
+                continue
+            if question["type"] == "abcd":
+                for answer in question["answers"]:
+                    if answer["is_correct"]:
+                        for submit_answer in submit_answers:
+                            if (
+                                submit_answer["id"] == answer["_id"]
+                                and submit_answer["answer"] is True
+                            ):
+                                scoring[question["_id"]]["points"] = float(question["points"])
+            elif question["type"] == "abcd.multiple":
+                multiplier = 0
+                for answer in question["answers"]:
+                    for submit_answer in submit_answers:
+                        if submit_answer["id"] == answer["_id"]:
+                            if submit_answer["answer"] == answer["is_correct"]:
+                                multiplier += answer["positive"]
+                            else:
+                                multiplier -= answer["negative"]
+                if multiplier < 0:
+                    multiplier = 0
+                elif multiplier > 100:
+                    multiplier = 100
+
+                scoring[question["_id"]]["points"] = question["points"] * multiplier / 100
+
+    enrolled_quiz.scoring = scoring
+
+    enrolled_quiz.save()
+
+
+# Helper function that renders a markdown content of question and its possible answers to HTML and returns it.
+def quiz_to_html(quiz_directory: str, quiz: dict):
+    result = []
+
+    for question in quiz["questions"]:
+        question_render = {
+            "id": question.get("_id"),
+            "type": question["type"],
+            "points": question["points"],
+            "name": question["name"],
+            "htmlContent": process_markdown(quiz_directory, question["content"], "quiz").content,
+        }
+        if question.get("answers"):
+            answers = []
+            for answer in question["answers"]:
+                answers.append(
+                    {
+                        "id": answer.get("_id"),
+                        "htmlContent": process_markdown(
+                            quiz_directory, answer["answer_content"], "quiz"
+                        ).content,
+                    }
+                )
+            question_render["answers"] = answers
+        result.append(question_render)
+
+    return result


### PR DESCRIPTION
Added base components and business logic for quizzes. With this, it's possible to:

From teacher pov:

- CRUD operations on quiz model
- Edit content of quiz
- View quiz
- Assign quiz
- Score quiz

From student pov:

- Enroll quiz
- View quiz results

It's still not "integrated" into Kelvin UI, it's required to call endpoints directly. 

I apologize that this one is quite large, probably largest, but I believe it will not be problematic to read. The next ones will be divisible better.