### PR TITLE
Fix missing `order_by` in task and student list

### DIFF
--- a/frontend/src/Autocomplete.svelte
+++ b/frontend/src/Autocomplete.svelte
@@ -14,7 +14,8 @@ let focused = false;
 let highlight_row = -1;
 
 onMount(async () => {
-  let res = await fetch('api/task-list?sort=asc');
+  // TODO: this only fetches the 100 newest tasks, that doesn't really work..
+  let res = await fetch('api/task-list?sort=desc');
   res = await res.json();
   items = res['tasks'];
 });


### PR DESCRIPTION
So, the good news is that this was easy to fix. The bad news is that it was broken even before we broke it recently =D The autocomplete tries to download all tasks from Kelvin (there are more than 3 thousand tasks at the moment), which is really not a good idea, and will not work.. It either needs to be reimplemented or we should remove it completely.

At the very least, it should only download tasks from the given subject. I will do that in a follow-up PR.

Related issue: https://github.com/mrlvsb/kelvin/issues/637