### PR TITLE
fix (java-pipeline): fix missing parser for unit test ended as error …

### DIFF
--- a/evaluator/images/java/Dockerfile
+++ b/evaluator/images/java/Dockerfile
@@ -6,15 +6,17 @@ RUN apt-get update && \
     python3-pip \
     wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz -P /tmp
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz -P /tmp
 RUN tar xf /tmp/apache-maven-*-bin.tar.gz -C /opt
-RUN ln -s /opt/apache-maven-3.9.4/ /opt/maven
+RUN ln -s /opt/apache-maven-3.9.9/ /opt/maven
 RUN echo 'export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))\n\
 export M2_HOME=/opt/maven\n\
 export MAVEN_HOME=/opt/maven\n\
 export PATH=$M2_HOME/bin:$PATH' > /etc/profile.d/maven.sh
 RUN chmod +x /etc/profile.d/maven.sh
 RUN /usr/bin/python3 -m pip install --break-system-packages bleach==5.0.1
+RUN mkdir /.m2
+RUN chmod u+rwx,g+rwx,o+rwx /.m2
 
 ADD entry.py /
 CMD /entry.py

--- a/evaluator/images/java/entry.py
+++ b/evaluator/images/java/entry.py
@@ -39,10 +39,26 @@ def parse_tests_report(path):
                 success = True
                 message = ""
                 failure = testcase.find("./failure")
-
+                error = testcase.find("./error")
+                sysoutNode = testcase.find("./system-out")
                 if failure is not None:
                     success = False
-                    message = failure.get("message", "") + "\n" + (failure.text or "").strip()
+                    message = (
+                        "Test FAILURE:\n"
+                        + failure.get("message", "")
+                        + "\n"
+                        + (failure.text or "").strip()
+                    )
+                if error is not None:
+                    success = False
+                    message = (
+                        "Test ERROR:\n"
+                        + error.get("message", "")
+                        + "\n"
+                        + (error.text or "").strip()
+                    )
+                if sysoutNode is not None:
+                    message = message + "\n\n" + (sysoutNode.text or "").strip()
 
                 tests.append(
                     {
@@ -88,7 +104,7 @@ def build_java_project(run_tests: bool) -> BuildResult:
     # build or build+run tests
     tests_path = "target/surefire-reports"
     env = os.environ.copy()
-    cmd = ["mvn", "clean"]
+    cmd = ["mvn", "--no-transfer-progress", "clean"]
     if run_tests:
         cmd += ["test", "-Dmaven.test.failure.ignore=true"]
     else:

--- a/templates/web/report.html
+++ b/templates/web/report.html
@@ -5,7 +5,7 @@
   {% if result.html or result.tests %}
   <h5{% if result.failed %} class="text-danger"{% endif %}>
       {{ result.title }}
-      {% if result.failed %} 
+      {% if result.failed %}
         - FAILED
       {% endif %}
       {% if result.tests %}
@@ -27,7 +27,7 @@
                 {% if test.title %}{{ test.title }}{% else %} {{ test.name }} {% endif %}
                 {% if test.title and test.title != test.name %} <span>({{ test.name }})</span>{% endif %}
             </h5>
-            
+
         </div>
         <div class="card-body">
 {% if test.errors %}
@@ -38,7 +38,7 @@
 </ul>
 {% endif %}
 {% if test.command or test.message %}
-<pre style="filter: opacity(.7);">
+<pre style="filter: opacity(.7);max-height: 15rem;">
 {% if test.command %}$ {{ test.command }}{% endif %}{% if test.message %}
 {{ test.message }}{%endif%}
 </pre>


### PR DESCRIPTION
…not only failure

- add /.m2 folder for java pipeline docker image to avoid problem with missing home for some user and running maven
- fix entry script for java pipeline docker image to parse result for unit test ended with result error not only with result failure
- change style for unit test result view in result page to limit height for long stack traces and std outputs