### PR TITLE
Move comments for non-existent files to summary

### DIFF
--- a/web/views/student.py
+++ b/web/views/student.py
@@ -694,7 +694,7 @@ def submit_comments(request, assignment_id, login, submit_num):
     summary_comments = []
     for comment in Comment.objects.filter(submit_id=submit.id).order_by("id"):
         try:
-            if not comment.source:
+            if not comment.source or comment.source not in result:
                 summary_comments.append(dump_comment(comment))
             else:
                 max_lines = result[comment.source]["content"].count("\n")


### PR DESCRIPTION
In logs I can see that sometimes there is a user generated comment for a file that is not found. I'm not exactly sure how it can happen (maybe the file disappeared from disk or cannot be loaded?), but in any case we should not error out in that case. This hack moves the comment to the summary in that case.