### PR TITLE
Do not allow connections through non-canonical hosts in nginx

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -15,6 +15,11 @@ http {
         ssl_certificate /etc/nginx/certs/fullchain.pem;
         ssl_certificate_key /etc/nginx/certs/privkey.pem;
 
+        # Deny illegal Host headers
+        if ($host !~* ^(kelvin.cs.vsb.cz)$ ) {
+            return 444;
+        }
+
         location / {
             uwsgi_pass  django;
             include uwsgi_params;


### PR DESCRIPTION
The invalid host exception was super spammy. I wanted to ignore it first, but I realized that denying these requests is a much better solution than them resulting in a 500 server error (this is kinda stupid behavior btw, Django should really return 400 errors for these...).