### PR TITLE
Added filtering of tasks based on a task types

### DIFF
--- a/api/views/default.py
+++ b/api/views/default.py
@@ -240,6 +240,7 @@ def class_detail_list(request):
                 "deadline": assignment.deadline,
                 "max_points": assignment.max_points,
                 "students": {s["username"]: {"username": s["username"]} for s in students},
+                "task_type": assignment.task.type,
             }
 
             for score in assignedtask_results(

--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -9,6 +9,7 @@ import { fetch } from './api.js';
 import { fs, currentPath, cwd, openedFiles } from './fs.js';
 import SyncLoader from './SyncLoader.svelte';
 import Modal from './Modal.svelte';
+import { task_types } from './taskTypes';
 
 export let params = {};
 
@@ -379,14 +380,13 @@ async function deleteTask(proceed) {
             <div class="input-group mb-3">
               <span class="input-group-text">Task type:</span>
               <select class="form-control form-control-sm" bind:value={task.type}>
-                {#if task.type == null}
-                  <option value={null}>None</option>
-                {/if}
-                <option value="homework">Homework</option>
-                <option value="exam">Exam</option>
-                <option value="project">Project</option>
-                <option value="laboratory">Laboratory</option>
-                <option value="other">Other</option>
+                {#each task_types as { key, value }}
+                  {#if task.type === null && key === null}
+                    <option value={null}>None</option>
+                  {:else if key !== null}
+                    <option value={key}>{value}</option>
+                  {/if}
+                {/each}
               </select>
             </div>
           </div>

--- a/frontend/src/TaskFilter.svelte
+++ b/frontend/src/TaskFilter.svelte
@@ -1,0 +1,21 @@
+<script>
+import { task_types } from './taskTypes.js';
+
+export let task_type = null;
+
+function setTaskType(type) {
+  task_type = type;
+}
+</script>
+
+<div class="ms-auto">
+  <div class="input-group">
+    {#each task_types as { key, value }}
+      <button
+        type="button"
+        class="btn btn-dark {key == task_type ? 'active' : ''}"
+        on:click={() => setTaskType(key)}
+        on:change>{value}</button>
+    {/each}
+  </div>
+</div>

--- a/frontend/src/taskTypes.js
+++ b/frontend/src/taskTypes.js
@@ -1,0 +1,8 @@
+export const task_types = [
+    { key: null, value: 'All' },
+    { key: 'homework', value: 'Homework' },
+    { key: 'exam', value: 'Exam' },
+    { key: 'project', value: 'Project' },
+    { key: 'laboratory', value: 'Laboratory' },
+    { key: 'other', value: 'Other' }
+];


### PR DESCRIPTION
Fixes #600
Filters tasks by one task type in the main view, it also calculates the points for the type. 
Right now it looks like this
![image](https://github.com/user-attachments/assets/3226683e-5433-46b5-bbb8-fc4a83bead7d). It could also be changed to a select, but i was told, that this would be quicker for the teachers.

