### PR TITLE
Hide nginx version

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -3,6 +3,8 @@ events {
 }
 
 http {
+    server_tokens off;
+
     upstream django {
         server unix:///socket/kelvin.sock;
     }


### PR DESCRIPTION
Exposed server information can lead attackers to find version-specific server vulnerabilities that can be used to exploit unpatched servers.

![Untitled](https://github.com/user-attachments/assets/eac591b1-6e84-4af7-b129-a4f8d5cdfa20)

