### PR TITLE
Add relative deadline button

### DIFF
--- a/frontend/src/EditTask.svelte
+++ b/frontend/src/EditTask.svelte
@@ -193,6 +193,16 @@ function assignSameToAll(templateClass) {
   });
 }
 
+function setRelativeDeadlineToAssigned(assigned, deadline) {
+  const diff = new Date(deadline) - new Date(assigned);
+  task.classes = task.classes.map((cl) => {
+    if (cl.assigned) {
+      cl.deadline = new Date(new Date(cl.assigned).getTime() + diff);
+    }
+    return cl;
+  });
+}
+
 async function duplicateTask() {
   let res = await fetch(`/api/tasks/${task.id}/duplicate`, {
     method: 'POST'
@@ -312,7 +322,8 @@ async function deleteTask(proceed) {
                         bind:to={clazz.deadline}
                         semesterBeginDate={$semester.begin}
                         onFromDuplicateClick={setAssignedDateToVisible}
-                        onToDuplicateClick={setDeadlineToAssigned} />
+                        onToDuplicateClick={setDeadlineToAssigned}
+                        onToRelativeClick={setRelativeDeadlineToAssigned} />
                       <div class="col-md">
                         <div class="input-group">
                           <input

--- a/frontend/src/TimeRange.svelte
+++ b/frontend/src/TimeRange.svelte
@@ -6,6 +6,7 @@ export let timeOffsetInWeek;
 export let semesterBeginDate;
 export let onFromDuplicateClick;
 export let onToDuplicateClick;
+export let onToRelativeClick;
 
 let fromEl, toEl;
 let instanceFrom, instanceTo;
@@ -108,5 +109,12 @@ $: if (instanceTo) {
     disabled={!to}
     on:click|preventDefault={() => onToDuplicateClick(to)}>
     <span class="iconify" data-icon="mdi:content-duplicate"></span>
+  </button>
+  <button
+    class="btn btn-sm btn-secondary"
+    title="Set relative deadline to all assigned classes"
+    disabled={!to}
+    on:click|preventDefault={() => onToRelativeClick(from, to)}>
+    <span class="iconify" data-icon="mdi:calendar-sync"></span>
   </button>
 </div>


### PR DESCRIPTION
Fixes #551
This is the way that I understood relative deadline. You specify start and end in the first class, and the just specify the start of each of the other classes and then just copies the relative deadline. So the deadline would be Assigned + (diff from the one that it was clicked from).