### PR TITLE
Changed white font color to grayish in dark mode

### DIFF
--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -42,4 +42,9 @@ html[data-bs-theme='dark'] {
     .d2h-file-header {
         background-color: #343434;
     }
+    th,
+    td,
+    .btn-dark {
+        color: var(--bs-body-color);
+    }
 }


### PR DESCRIPTION
Fixes #573

Updated 2 elements, 1 class with the greyish color. The td, th tags i think caused the main problem. The global color change wouldn't change the color of these elements, or atleast with my experiments it didn't.
Current state:
![image](https://github.com/user-attachments/assets/e46ade8b-7eb2-4bd1-a2da-f2fd0d67a9d1)
