### PR TITLE
Handle missing `hard_deadline` in `task_detail`

### DIFF
--- a/api/views/default.py
+++ b/api/views/default.py
@@ -633,7 +633,7 @@ def task_detail(request, task_id=None):
                         if cl.get("deadline", None)
                         else None,
                         "max_points": cl.get("max_points", None),
-                        "hard_deadline": cl.get("hard_deadline"),
+                        "hard_deadline": cl.get("hard_deadline", False),
                     },
                 )
             else:


### PR DESCRIPTION
This logic is brutal.. When a new task is being created, the `EditTask` components loads classes from `/api/subject`, and then monkey patches additional attributes to these classes, and then it resends the classes (which then actually represent assigned tasks) to `task_detail`. This should be rewritten from scratch =D

This PR is mostly a hotfix.

Fixes: https://github.com/mrlvsb/kelvin/issues/677