### PR TITLE
support for uploading 7z files

### DIFF
--- a/common/upload.py
+++ b/common/upload.py
@@ -1,6 +1,7 @@
 import os
 import re
 import zipfile
+import py7zr
 from os.path import basename, dirname
 from typing import List
 
@@ -37,20 +38,36 @@ class Uploader:
             raise Exception(f"Invalid file type {type(file)}")
 
 
-class ZipUploader(Uploader):
-    def __init__(self, file):
+class ArchiveUploader(Uploader):
+    def __init__(self, file, format):
         super().__init__()
-        self.archive = zipfile.ZipFile(file, "r")
+        self.format = format
+        self.archive = None
+
+        if format == "zip":
+            self.archive = zipfile.ZipFile(file,"r")
+        elif format == "7z":
+            self.archive = py7zr.sevenzipfile(file, mode="r")
+
 
     def get_files(self):
-        return [(f.filename, f) for f in self.archive.filelist if not f.is_dir()]
+        if self.format == "zip":
+            return [(f.filename, f) for f in self.archive.filelist if not f.is_dir()]
+        elif self.format == "7z":
+            return [(name, None) for name in self.archive.getnames()]
+        return []
 
     def upload_file(self, path: str, file, submit: Submit):
-        self.check_file_type(file, zipfile.ZipInfo)
-
         target_path = submit.source_path(path)
         os.makedirs(dirname(target_path), exist_ok=True)
-        self.archive.extract(path, path=submit.dir())
+
+        if self.format == "zip":
+            self.archive.extract(path, path=submit.dir())
+        elif self.format == "7z":
+            extracted = self.archive.read([path])
+            with open(target_path, 'wb') as f:
+               f.write(extracted[path].read())
+
         self.count += 1
         return target_path
 
@@ -120,8 +137,10 @@ class TooManyFilesError(BaseException):
 
 
 def upload_submit_files(submit: Submit, paths: List[str], files: List[UploadedFile]):
-    if len(paths) == 1 and get_extension(paths[0]) == ".zip":
-        uploader = ZipUploader(files[0])
+    if len(paths) == 1 and (zipfile.is_zipfile(files[0]) or py7zr.is_7zfile(files[0])):
+        format = ("zip","7z")[py7zr.is_7zfile(files[0])]
+        uploader = ArchiveUploader(files[0],format)
+
     else:
         uploader = FileUploader(paths, files)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "Unidecode==1.3.6",
     "uWSGI==2.0.24",
     "django-ipware==7.0.1",
+    "py7zr==1.0.0"
 ]
 
 [tool.uv]


### PR DESCRIPTION
#693 
Add 7z archive support to uploader

- Added support for extracting .7z files using py7zr

- Unified ZIP and 7z handling in a single ArchiveUploader class

- Updated pyproject.toml to include py7zr as a dependency

Let me know if you want to tag this as a fix, feature, or refactor, this is my one of the first open source contributions!
