### PR TITLE
Update Cargo Docker image to 1.90.0

### DIFF
--- a/evaluator/images/cargo/Dockerfile
+++ b/evaluator/images/cargo/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82.0
+FROM rust:1.90.0
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/evaluator/images/cargo/entry.py
+++ b/evaluator/images/cargo/entry.py
@@ -134,7 +134,7 @@ def run_cargo(command: str, args: List[str]) -> BuildResult:
 [package]
 name = "submit"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 """
         lib_target = get_param("lib", default="False") == "True"
         if lib_target:


### PR DESCRIPTION
Shouldn't be merged until the 1.90.0 Docker image is actually released (should be Thursday/Friday this week).