### PR TITLE
Fix of edit link in Class Detail

### DIFF
--- a/frontend/src/ClassDetail.svelte
+++ b/frontend/src/ClassDetail.svelte
@@ -222,7 +222,7 @@ let showSummary = false;
                       </a>
                       <div class="more-content border shadow rounded bg-body p-1">
                         {assignment.name}
-                        <a href="/task/edit/{assignment.task_id}" use:link title="Edit"
+                        <a use:link={`/task/edit/${assignment.task_id}`} title="Edit"
                           ><span class="iconify" data-icon="clarity:edit-solid"></span></a>
                         <div style="display: flex; align-items: center;">
                           <a href={assignment.plagcheck_link} title="Plagiarism check"


### PR DESCRIPTION
I wasn't able to recreate the problem on the local, for me it worked without the hash, but this should fix the problem.
Seems like the use:link have problem with rerendering in use with the spa-router, please correct me if I am wrong :). 

Fixes #706
