### PR TITLE
Add link to the next unevaluated submit to teacher submit view

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -357,6 +357,14 @@ User.add_to_class("notification_str", lambda self: self.get_full_name())
 
 
 def assignedtask_results(assignment, students=None, **kwargs):
+    """
+    Returns a list of students to gether with their submits.
+    [{
+        "student": login,
+        "submits": <count of submits>,
+        "submits_with_assigned_pts": <count of submits without assigned points>,
+    }]
+    """
     results = {}
 
     if not students:

--- a/templates/web/task_detail.html
+++ b/templates/web/task_detail.html
@@ -138,12 +138,18 @@
             {% endif %}
 
             {% if is_teacher and not upload%}
-              {% if submit and submit.assignment.max_points is not None %}
-                <li class="nav-item ms-auto">
-                  {% include 'web/teacher/form_assign_points.html' %}
-
-                <li>
-              {% endif %}
+                <li class="nav-item ms-auto d-flex align-items-center">
+                    {% if next_url_to_evaluate %}
+                    <div class="me-1" title="Link to the next student thas has unevaluated submit(s) for the same task.">
+                        <a class="btn btn-sm btn-info" href="{{ next_url_to_evaluate }}">Next student to evaluate</a>
+                    </div>
+                    {% endif %}
+                    {% if submit and submit.assignment.max_points is not None %}
+                    <div>
+                    {% include 'web/teacher/form_assign_points.html' %}
+                    </div>
+                    {% endif %}
+                </li>
             {% else %}
             <li class="nav-item ms-auto">
                 <ul class="navbar-nav">

--- a/templates/web/teacher/form_assign_points.html
+++ b/templates/web/teacher/form_assign_points.html
@@ -1,6 +1,6 @@
 <form class="float-end" action="{% url 'submit_assign_points' submit.id %}" method="POST">
   {% csrf_token %} 
-  <div class="input-group input-group-sm mt-1 me-1">
+  <div class="input-group input-group-sm me-1">
     <input type="number" name="assigned_points" step="any" min=-100 class="form-control" placeholder="points" style="width: 70px" value="{{ submit.assigned_points }}">
     <div class="input-group-text"> / {{ submit.assignment.max_points }}</div>
   </div>

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4"
 
 [[package]]
@@ -452,7 +452,6 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pygraphviz" },
     { name = "pymdown-extensions" },
-    { name = "pyrefly" },
     { name = "pyserde" },
     { name = "python-dotenv" },
     { name = "python-magic" },
@@ -469,6 +468,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pyrefly" },
     { name = "ruff" },
 ]
 
@@ -499,7 +499,6 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.1" },
     { name = "pygraphviz", specifier = "==1.7" },
     { name = "pymdown-extensions", specifier = "==10.10.1" },
-    { name = "pyrefly", specifier = "==0.18.0" },
     { name = "pyserde", specifier = "==0.13.1" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "python-magic", specifier = "==0.4.27" },
@@ -516,6 +515,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=3.8.0" },
+    { name = "pyrefly", specifier = "==0.18.0" },
     { name = "ruff", specifier = "==0.6.3" },
 ]
 


### PR DESCRIPTION
Suggested by @kozusznik.

<img width="391" height="152" alt="image" src="https://github.com/user-attachments/assets/80c12d85-d0a2-4022-9533-bd5bb38f4611" />

The fetch of the submits should really be done in an SQL query, but we already load the submits into memory at a couple of other places, so :shrug: The code for sorting the students would be so much nicer with iterators :(