### PR TITLE
Make the "Next student to evaluate" link point directly to source code

### DIFF
--- a/templates/web/task_detail.html
+++ b/templates/web/task_detail.html
@@ -141,7 +141,7 @@
                 <li class="nav-item ms-auto d-flex align-items-center">
                     {% if next_url_to_evaluate %}
                     <div class="me-1" title="Link to the next student thas has unevaluated submit(s) for the same task.">
-                        <a class="btn btn-sm btn-info" href="{{ next_url_to_evaluate }}">Next student to evaluate</a>
+                        <a class="btn btn-sm btn-info" href="{{ next_url_to_evaluate }}#src">Next student to evaluate</a>
                     </div>
                     {% endif %}
                     {% if submit and submit.assignment.max_points is not None %}


### PR DESCRIPTION
There should always be a source code available, because we know that there is at least a single submit for the given student, otherwise the link wouldn't point to it.

Suggested by Pavel Dohnálek.