### PR TITLE
Pin Python version to 3.12 in `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kelvin"
 version = "0.1.0"
 description = "Code examination tool"
 readme = "README.md"
-requires-python = "~=3.12"
+requires-python = "==3.12.*"
 
 dependencies = [
     "beautifulsoup4==4.11.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12, <4"
+requires-python = "==3.12.*"
 
 [[package]]
 name = "asgiref"


### PR DESCRIPTION
Also get rid of warning message when running `uv`.