### PR TITLE
Create prohibit_during_test decorator

### DIFF
--- a/common/comment.py
+++ b/common/comment.py
@@ -9,8 +9,10 @@ from common.dto import CommentDTO
 from django.contrib.auth.models import User as DjangoUser
 from common.exceptions.http_exceptions import HttpException403
 from common.models import Submit, Comment
+from common.utils import prohibit_during_test
 
 
+@prohibit_during_test
 def create_submit_comment(
     submit: Submit,
     author: DjangoUser,
@@ -40,6 +42,7 @@ def create_submit_comment(
     return comment
 
 
+@prohibit_during_test
 def update_submit_comment(
     submit: Submit,
     comment_id: int,
@@ -85,6 +88,7 @@ def update_submit_comment(
     return comment
 
 
+@prohibit_during_test
 def delete_submit_comment(comment_id: int, author: DjangoUser):
     """
     Deletes a comment if authored by the requester and removes related notifications.

--- a/common/utils.py
+++ b/common/utils.py
@@ -147,7 +147,7 @@ def prohibit_during_test(function):
         if is_teacher(request.user):
             return function(*args, **kwargs)
 
-        active_exams = get_active_exams_at(request.user, datetime.now(), timedelta(0))
+        active_exams = get_active_exams_at(request.user, datetime.now(), timedelta(0.5))
 
         if not active_exams:
             return function(*args, **kwargs)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,14 +1,16 @@
 import io
 import re
 import tarfile
-from datetime import timedelta
+from datetime import timedelta, datetime
 from functools import lru_cache
 from typing import NewType
 
 import django.contrib.auth.models
 import requests
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
+from django.http.response import Http404
 from ipware import get_client_ip
 
 from .inbus import inbus
@@ -123,3 +125,50 @@ def build_evaluation_download_uri(request, location):
     if settings.EVALUATION_LINK_BASEURL:
         return settings.EVALUATION_LINK_BASEURL + location
     return request.build_absolute_uri(location)
+
+
+def prohibit_during_test(function):
+    """
+    Decorator that restricts access to a page if the student has any ongoing exams.
+
+    The decorated function must accept the following parameters:
+        - request
+        - assignment_id
+
+    During the ongoing test access is granted only for ongoing exams and tasks whose hard deadline ends before the exam starts.
+    """
+
+    def wrapper(*args, **kwargs):
+        from .models import AssignedTask
+        from .task import get_active_exams_at
+
+        request = args[0]
+
+        if is_teacher(request.user):
+            return function(*args, **kwargs)
+
+        active_exams = get_active_exams_at(request.user, datetime.now(), timedelta(0))
+
+        if not active_exams:
+            return function(*args, **kwargs)
+
+        assignment_id = kwargs.get("assignment_id")
+
+        try:
+            assignment = AssignedTask.objects.get(pk=assignment_id)
+        except AssignedTask.DoesNotExist:
+            raise Http404(f"AssignedTask with id {assignment_id} not found")
+
+        # if task is any of ongoing exams allow it
+        for exam in active_exams:
+            if exam.pk == assignment_id:
+                return function(*args, **kwargs)
+
+        if assignment.has_hard_deadline() and assignment.deadline is not None:
+            # check if the deadline has expired before the start of all exams
+            if all(map(lambda e: assignment.deadline < e.assigned, active_exams)):
+                return function(*args, **kwargs)
+
+        raise PermissionDenied("Access to this task is prohibited during exam")
+
+    return wrapper

--- a/common/utils.py
+++ b/common/utils.py
@@ -10,10 +10,11 @@ import requests
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
-from django.http.response import Http404
 from ipware import get_client_ip
 
+from .exceptions.http_exceptions import HttpException404, HttpException403
 from .inbus import inbus
+
 
 IPAddressString = NewType("IPAddressString", str)
 
@@ -157,7 +158,7 @@ def prohibit_during_test(function):
         try:
             assignment = AssignedTask.objects.get(pk=assignment_id)
         except AssignedTask.DoesNotExist:
-            raise Http404(f"AssignedTask with id {assignment_id} not found")
+            raise HttpException404(f"AssignedTask with id {assignment_id} not found")
 
         # if task is any of ongoing exams allow it
         for exam in active_exams:
@@ -169,6 +170,6 @@ def prohibit_during_test(function):
             if all(map(lambda e: assignment.deadline < e.assigned, active_exams)):
                 return function(*args, **kwargs)
 
-        raise PermissionDenied("Access to this task is prohibited during exam")
+        raise HttpException403("Access to this task is prohibited during exam")
 
     return wrapper

--- a/common/utils.py
+++ b/common/utils.py
@@ -14,7 +14,6 @@ from ipware import get_client_ip
 from .exceptions.http_exceptions import HttpException403
 from .inbus import inbus
 
-
 IPAddressString = NewType("IPAddressString", str)
 
 
@@ -131,11 +130,16 @@ def prohibit_during_test(function):
     """
     Decorator that restricts access to a page if the student has any ongoing exams.
 
-    The decorated function must accept the following parameters:
-        - request
-        - assignment_id
+    The decorated function must accept one of the following parameter sets:
+    - request and assignment_id, or
+    - author
 
-    During the ongoing test access is granted only for ongoing exams and tasks whose hard deadline ends before the exam starts.
+    Use the first option when access to specific test tasks should still be allowed.
+    Use the second option to disable all interactions during an ongoing exam.
+
+    Currently:
+    - The first option is used for the task page and its subpages.
+    - The second option is used to disable all comments.
     """
 
     def wrapper(*args, **kwargs):
@@ -148,6 +152,7 @@ def prohibit_during_test(function):
             author = args[0].user
             assignment_id = kwargs.get("assignment_id")
 
+        # Allways allow teacher access
         if is_teacher(author):
             return function(*args, **kwargs)
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -12,7 +12,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from ipware import get_client_ip
 
-from .exceptions.http_exceptions import HttpException404, HttpException403
+from .exceptions.http_exceptions import HttpException403
 from .inbus import inbus
 
 
@@ -140,7 +140,6 @@ def prohibit_during_test(function):
     """
 
     def wrapper(*args, **kwargs):
-        from .models import AssignedTask
         from .task import get_active_exams_at
 
         request = args[0]
@@ -155,19 +154,9 @@ def prohibit_during_test(function):
 
         assignment_id = kwargs.get("assignment_id")
 
-        try:
-            assignment = AssignedTask.objects.get(pk=assignment_id)
-        except AssignedTask.DoesNotExist:
-            raise HttpException404(f"AssignedTask with id {assignment_id} not found")
-
         # if task is any of ongoing exams allow it
         for exam in active_exams:
             if exam.pk == assignment_id:
-                return function(*args, **kwargs)
-
-        if assignment.has_hard_deadline() and assignment.deadline is not None:
-            # check if the deadline has expired before the start of all exams
-            if all(map(lambda e: assignment.deadline < e.assigned, active_exams)):
                 return function(*args, **kwargs)
 
         raise HttpException403("Access to this task is prohibited during exam")

--- a/common/utils.py
+++ b/common/utils.py
@@ -8,7 +8,6 @@ from typing import NewType
 import django.contrib.auth.models
 import requests
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from ipware import get_client_ip
 
@@ -142,23 +141,28 @@ def prohibit_during_test(function):
     def wrapper(*args, **kwargs):
         from .task import get_active_exams_at
 
-        request = args[0]
+        if "author" in kwargs:
+            author = kwargs.get("author")
+            assignment_id = None
+        else:
+            author = args[0].user
+            assignment_id = kwargs.get("assignment_id")
 
-        if is_teacher(request.user):
+        if is_teacher(author):
             return function(*args, **kwargs)
 
-        active_exams = get_active_exams_at(request.user, datetime.now(), timedelta(0.5))
+        active_exams = get_active_exams_at(author, datetime.now(), timedelta(0.5))
 
         if not active_exams:
             return function(*args, **kwargs)
 
-        assignment_id = kwargs.get("assignment_id")
+        if assignment_id is not None:
+            # if task is any of ongoing exams allow it
+            for exam in active_exams:
+                if exam.pk == assignment_id:
+                    return function(*args, **kwargs)
 
-        # if task is any of ongoing exams allow it
-        for exam in active_exams:
-            if exam.pk == assignment_id:
-                return function(*args, **kwargs)
-
-        raise HttpException403("Access to this task is prohibited during exam")
+            raise HttpException403("Access to this task is prohibited during exam")
+        raise HttpException403("Comments are disabled during exam")
 
     return wrapper

--- a/common/utils.py
+++ b/common/utils.py
@@ -156,7 +156,7 @@ def prohibit_during_test(function):
         if is_teacher(author):
             return function(*args, **kwargs)
 
-        active_exams = get_active_exams_at(author, datetime.now(), timedelta(0.5))
+        active_exams = get_active_exams_at(author, datetime.now(), timedelta(minutes=30))
 
         if not active_exams:
             return function(*args, **kwargs)

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -7,7 +7,6 @@ import subprocess
 import tarfile
 import tempfile
 from collections import namedtuple
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -53,7 +52,6 @@ from common.models import (
 )
 from common.plagcheck.moss import PlagiarismMatch, moss_result
 from common.submit import SubmitRateLimited, store_submit, SubmitPastHardDeadline, is_file_small
-from common.task import get_active_exams_at
 from common.upload import MAX_UPLOAD_FILECOUNT, TooManyFilesError
 from common.utils import is_teacher, prohibit_during_test
 from evaluator.results import EvaluationResult
@@ -796,6 +794,7 @@ def raw_result_content(
                                 return HttpResponse(file_content, content_type=file_mime)
                             return file_response(file_content, file_name, "text/plain")
     raise HttpException404()
+
 
 @prohibit_during_test
 def submit_download(

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -53,7 +53,7 @@ from common.models import (
 from common.plagcheck.moss import PlagiarismMatch, moss_result
 from common.submit import SubmitRateLimited, store_submit, SubmitPastHardDeadline, is_file_small
 from common.upload import MAX_UPLOAD_FILECOUNT, TooManyFilesError
-from common.utils import is_teacher
+from common.utils import is_teacher, prohibit_during_test
 from evaluator.results import EvaluationResult
 from evaluator.evaluation import EvaluationContext
 from kelvin.settings import BASE_DIR, MAX_INLINE_CONTENT_BYTES
@@ -188,8 +188,8 @@ def student_index(request: HttpRequest) -> HttpResponse:
     ):
         semesters.append(
             {
-                "label": f'{year}/{year + 1} {"winter" if winter else "summer"}',
-                "value": f'{year}{"W" if winter else "S"}',
+                "label": f"{year}/{year + 1} {'winter' if winter else 'summer'}",
+                "value": f"{year}{'W' if winter else 'S'}",
             }
         )
 
@@ -291,6 +291,7 @@ def build_plagiarism_entries(login: str, matches: List[PlagiarismMatch]) -> List
 
 
 @login_required()
+@prohibit_during_test
 def task_detail(
     request: HttpRequest,
     assignment_id: int,
@@ -525,6 +526,7 @@ def submit_source(request: HttpRequest, submit_id: int, path: str) -> HttpRespon
 
 
 @login_required
+@prohibit_during_test
 def submit_diff(
     request: HttpRequest, login: str, assignment_id: int, submit_a: int, submit_b: int
 ) -> HttpResponse:
@@ -793,7 +795,7 @@ def raw_result_content(
                             return file_response(file_content, file_name, "text/plain")
     raise HttpException404()
 
-
+@prohibit_during_test
 def submit_download(
     request: HttpRequest, assignment_id: int, login: str, submit_num: int
 ) -> HttpResponse:
@@ -829,6 +831,7 @@ def ui(request: HttpRequest) -> HttpResponse:
 
 
 @csrf_exempt
+@prohibit_during_test
 def upload_results(
     request: HttpRequest, assignment_id: int, submit_num: int, login: str
 ) -> HttpResponse:

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -7,6 +7,7 @@ import subprocess
 import tarfile
 import tempfile
 from collections import namedtuple
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -52,6 +53,7 @@ from common.models import (
 )
 from common.plagcheck.moss import PlagiarismMatch, moss_result
 from common.submit import SubmitRateLimited, store_submit, SubmitPastHardDeadline, is_file_small
+from common.task import get_active_exams_at
 from common.upload import MAX_UPLOAD_FILECOUNT, TooManyFilesError
 from common.utils import is_teacher, prohibit_during_test
 from evaluator.results import EvaluationResult


### PR DESCRIPTION
Teachers sometimes allow students to upload materials for tests to Kelvin. So, I enabled viewing of assignments with a "Hard deadline" that expires before the start of the test. 

This means that if a teacher wants to allow students to upload test materials to Kelvin, they must create a task with a "hard deadline" before the test. It's a bit complicated, but I couldn't think of any other way to solve it.

Related to #603 