### PR TITLE
Use vite dev server with HMR support for dev mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "copy-dolos": "node copy-dolos.js",
         "build": "npm run copy-dolos && vue-tsc && vite build",
-        "dev": "npm run copy-dolos && vite build --watch --mode dev",
+        "dev": "npm run copy-dolos && vite dev --port 5173 --strictPort",
         "check": "vue-tsc && prettier --check src && eslint src",
         "fix": "prettier --write src && eslint --fix src",
         "test": "vitest"

--- a/kelvin/settings.py
+++ b/kelvin/settings.py
@@ -100,6 +100,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "web.views.common.template_context",
+                "django.template.context_processors.debug",
             ],
         },
     },

--- a/templates/web/layout.html
+++ b/templates/web/layout.html
@@ -29,7 +29,11 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{% static 'favicon/favicon-32x32.png' %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% static 'favicon/favicon-16x16.png' %}">
         <link rel="manifest" href="{% static 'favicon/site.webmanifest' %}">
+        {% if debug %}
+        <script type="module" src="http://localhost:5173/src/main.js"></script>
+        {% else %}
         <script src="{% static 'frontend.js' %}"></script>
+        {% endif %}
         <link rel="stylesheet" href="{% static 'frontend.css' %}">
         <title>{% block title %}Kelvin{% endblock %}</title>
     </head>


### PR DESCRIPTION
This pull request utilizes vite's dev server with HMR support, instead of full rebuild each time.
It shortens time, waiting for change to be visible in browser, and also automatically reload changed modules, showing change instantly in browser, without reloading.

How it works:
- Now with `npm run dev` you ran `vite dev` instead of `vite build --watch  --mode dev` - this ran the Vite dev server on port `5173`
- In django I enabled the `django.template.context_preprocessors.debug` which provides in debug mode variable call `debug` in templates, so we can identify, when the DEBUG mode is enabled in django
- Then I used that variable in [`layout.html`](https://github.com/mrlvsb/kelvin/blob/master/templates/web/layout.html)  to conditionally load static `frontend.js`file and load module from vite dev server (http://localhost:5173/src/frontend.js)
- When browser loads this `src/frontend.js` file from Vite dev server, the Vite starts building files on demand and also inject its HMR mechanism. The build files are then cached in memory.
- Every time user make some changes, Vite rebuilds relevant files, sends request to client via WebSocket, and client reloads that specific modules

Showcase:

https://github.com/user-attachments/assets/0b430415-d24d-486a-9686-acfe6add34b3



One problem is, that it statically use address `http://localhost:5173/src/frontend.js` so when this port is occupied, and Vite starts server on next available port (5174) the django will try to load `frontend.js` from wrong address.

For some reason I can't test that on my PC with DEBUG mode off, because of some static files error?
<img width="1293" height="341" alt="image" src="https://github.com/user-attachments/assets/6b714275-25f1-462e-9bdc-b55a849b523d" />
