### PR TITLE
Show teacher on submit page

### DIFF
--- a/templates/web/task_detail.html
+++ b/templates/web/task_detail.html
@@ -16,6 +16,9 @@
     <a href="/#/task/edit/{{task.id}}" class="text-muted" title="Edit task"><span class="iconify" data-icon="fa-solid:pen"></span></a>
     {% endif %}
 </h2>
+{% if teacher %}
+<h6>Class lecturer: {{ teacher }}</h6>
+{% endif %}
 {% if assigned %}
 <h6>Assigned: {{ assigned|date:"d.m.Y, G:i" }}, Time remaining: {{ assigned|timeuntil }}</h6>
 {% endif %}

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -360,6 +360,7 @@ def task_detail(request, assignment_id, submit_num=None, login=None):
     data = {
         # TODO: task and deadline can be combined into assignment ad deal with it in template
         "task": assignment.task,
+        "teacher": assignment.clazz.teacher.username,
         "assigned": assignment.assigned if is_announce else None,
         "deadline": assignment.deadline,
         "now": timezone.now(),


### PR DESCRIPTION
This has annoyed me for a couple of years - when I check plagiarism, it's really useful to see whose class it is, but before it was super annoying to find it (you had to go to the index page, use the right filter, and then Ctrl+F for the student).

The removed check is redundant, we started checking the student a couple of lines above since it was added.