### PR TITLE
Revert "Use vite dev server with HMR support for dev mode"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "copy-dolos": "node copy-dolos.js",
         "build": "npm run copy-dolos && vue-tsc && vite build",
-        "dev": "npm run copy-dolos && vite dev --port 5173 --strictPort",
+        "dev": "npm run copy-dolos && vite build --watch --mode dev",
         "check": "vue-tsc && prettier --check src && eslint src",
         "fix": "prettier --write src && eslint --fix src",
         "test": "vitest"

--- a/kelvin/settings.py
+++ b/kelvin/settings.py
@@ -100,7 +100,6 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "web.views.common.template_context",
-                "django.template.context_processors.debug",
             ],
         },
     },

--- a/templates/web/layout.html
+++ b/templates/web/layout.html
@@ -29,11 +29,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{% static 'favicon/favicon-32x32.png' %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% static 'favicon/favicon-16x16.png' %}">
         <link rel="manifest" href="{% static 'favicon/site.webmanifest' %}">
-        {% if debug %}
-        <script type="module" src="http://localhost:5173/src/main.js"></script>
-        {% else %}
         <script src="{% static 'frontend.js' %}"></script>
-        {% endif %}
         <link rel="stylesheet" href="{% static 'frontend.css' %}">
         <title>{% block title %}Kelvin{% endblock %}</title>
     </head>


### PR DESCRIPTION
Reverts mrlvsb/kelvin#750.

Sorry, but I have to revert the HMR PR. It was not working well, apart from the white/dark blinking, some pages just refused to load properly (e.g. the `/student/<login>` event log page).

CC @patrick11514