### PR TITLE
Inherit `HttpException` from `Exception`, not `BaseException`

### DIFF
--- a/common/exceptions/http_exceptions.py
+++ b/common/exceptions/http_exceptions.py
@@ -1,4 +1,4 @@
-class HttpException(BaseException):
+class HttpException(Exception):
     """
     Custom HTTP exception that can be used to report user-facing errors that will be rendered
     in a custom error page.


### PR DESCRIPTION
For some reason, error reporting completely breaks in Django when a `BaseException` is raised.
