### PR TITLE
Download single file in submit

### DIFF
--- a/frontend/src/TaskDetail.svelte
+++ b/frontend/src/TaskDetail.svelte
@@ -356,19 +356,23 @@ window.addEventListener('hashchange', goToSelectedLines);
               >{comments.automated}</span>
           {/if}
         {/if}
-      </span>{#if file.source.type == 'source' && file.source.content}<CopyToClipboard
+      </span>
+      {#if file.source.type == 'source' && file.source.content}
+        <CopyToClipboard
           content={() => file.source.content}
-          title="Copy the source code to the clipboard"
-          ><span class="iconify" data-icon="clarity:copy-to-clipboard-line" style="height: 20px"
-          ></span
-          ></CopyToClipboard
-        >{/if}
+          title="Copy the source code to the clipboard">
+          <span class="iconify" data-icon="clarity:copy-to-clipboard-line" style="height: 20px" />
+        </CopyToClipboard>
+      {/if}
+      <a class="text-body" href={file.source.content_url} download title="Download the file">
+        <span class="iconify" data-icon="clarity:download-line" style="height: 20px" />
+      </a>
     </h2>
     {#if file.opened}
       {#if file.source.error}
         <span class="text-muted">{file.source.error}</span>
       {:else if file.source.type == 'source'}
-        {#if file.source.content_url}
+        {#if file.source.content === null}
           Content too large, show <a href={file.source.content_url}>raw content</a>.
         {:else}
           <SubmitSource

--- a/web/views/student.py
+++ b/web/views/student.py
@@ -760,18 +760,16 @@ def submit_comments(
                 }
             result[name]["sources"].append(reverse("submit_source", args=[submit.id, source.virt]))
         else:
-            content = ""
-            content_url = None
+            content = None
+            content_url = reverse(
+                "submit_source", kwargs=dict(submit_id=submit.id, path=source.virt)
+            )
             error = None
 
             try:
                 if is_file_small(source.phys):
                     with open(source.phys) as f:
                         content = f.read()
-                else:
-                    content_url = reverse(
-                        "submit_source", kwargs=dict(submit_id=submit.id, path=source.virt)
-                    )
             except UnicodeDecodeError:
                 error = "The file contains binary data or is not encoded in UTF-8"
             except FileNotFoundError:


### PR DESCRIPTION
Closes #698.

This feature allows user to download one specific file using the same endpoint that is used for large or binary files. The file is always provided as downloadable using `download` attribute on HTML anchor tag.

<img width="1308" height="219" alt="image" src="https://github.com/user-attachments/assets/c20e5793-0e10-4b2f-a7f6-76dc099d45f3" />
