### PR TITLE
Bring back download button for source

### DIFF
--- a/common/submit.py
+++ b/common/submit.py
@@ -179,16 +179,14 @@ def fetch_submit_sources(submit: Submit) -> SubmitSources:
         # Text / fallback handling
         else:
             content_text: str = ""
-            content_url: str | None = None
             content_error: str | None = None
+            content_url = reverse("submit_source", args=[submit.id, source.virt])
 
             try:
                 # Load file contents when small enough, otherwise defer to URL
                 if is_file_small(source.phys):
                     with open(source.phys) as file_stream:
                         content_text = file_stream.read()
-                else:
-                    content_url = reverse("submit_source", args=[submit.id, source.virt])
             except UnicodeDecodeError:
                 content_error = "The file contains binary data or is not encoded in UTF-8"
             except FileNotFoundError:

--- a/frontend/src/Student/TaskDetail.vue
+++ b/frontend/src/Student/TaskDetail.vue
@@ -518,6 +518,15 @@ onUnmounted(() => {
         >
           <span class="iconify" data-icon="clarity:copy-to-clipboard-line" style="height: 20px" />
         </CopyToClipboard>
+
+        <a
+          class="text-body"
+          :href="file.source.content_url || file.source.src"
+          download
+          title="Download the file"
+        >
+          <span class="iconify" data-icon="clarity:download-line" style="height: 20px" />
+        </a>
       </h2>
 
       <template v-if="file.opened">


### PR DESCRIPTION
This PR brings back previously removed download button. Also will resolve https://github.com/mrlvsb/kelvin/issues/698#issue-3402658860

Previously button was doing backend API call, but I dont really see why it was implemented that way, when on frontend we already have whole file as plain text.

Fixes: https://github.com/mrlvsb/kelvin/issues/698