### PR TITLE
Make images full screen when clicked.

### DIFF
--- a/frontend/src/Student/TaskDetailContent.vue
+++ b/frontend/src/Student/TaskDetailContent.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import CopyToClipboard from '../components/CopyToClipboard.vue';
+import FullscreenImage from '../components/FullscreenImage.vue';
 import SubmitSource from '../components/submit/SubmitSource.vue';
 import { Comment, SourceFile, CommentCounts, SelectedRows } from '../types/TaskDetail';
 
@@ -114,10 +115,10 @@ const handleSaveComment = (
           />
         </template>
 
-        <img
+        <FullscreenImage
           v-else-if="file.source.type === 'img'"
           :src="file.source.src"
-          style="max-width: 100%"
+          alt="Image preview"
         />
 
         <video v-else-if="file.source.type === 'video'" style="max-width: 100%" controls>

--- a/frontend/src/components/FullscreenImage.vue
+++ b/frontend/src/components/FullscreenImage.vue
@@ -1,0 +1,73 @@
+<script lang="ts" setup>
+import { onMounted, onUnmounted, ref } from 'vue';
+
+let { src, alt } = defineProps<{
+  src: string;
+  alt?: string;
+}>();
+
+const fullscreenImageSrc = ref<string | null>(null);
+
+const openFullscreenImage = () => {
+  fullscreenImageSrc.value = src;
+};
+
+const closeFullscreenImage = () => {
+  fullscreenImageSrc.value = null;
+};
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    closeFullscreenImage();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown);
+});
+</script>
+
+<template>
+  <div>
+    <img :src="src" :alt="alt" class="preview-image" @click="openFullscreenImage" />
+
+    <div
+      v-if="fullscreenImageSrc"
+      class="fullscreen-overlay"
+      role="button"
+      aria-label="Close fullscreen image"
+      @click="closeFullscreenImage"
+    >
+      <img :src="fullscreenImageSrc" class="fullscreen-image" :alt="alt" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.preview-image {
+  cursor: zoom-in;
+  max-width: 100%;
+}
+
+.fullscreen-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  cursor: zoom-out;
+}
+
+.fullscreen-image {
+  max-width: 95vw;
+  max-height: 95vh;
+  object-fit: contain;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+</style>


### PR DESCRIPTION
This PR simply opens image to full screen when clicked. In previous PR, we had to limit images to max-width of container. Therefore, when image is wider its good to have ability to enlarge it. Videos have this "fullscreen" button by default.