### PR TITLE
Make .well-known directory accessible

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -48,6 +48,11 @@ http {
             gzip_vary on;
         }
 
+        location /.well-known {
+            alias /app/.well-known;
+            include /etc/nginx/mime.types;
+        }
+
         # This should be in sync with DATA_UPLOAD_MAX_MEMORY_SIZE from kelvin/settings.py
         client_max_body_size 100M;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - EVALUATION_LINK_BASEURL=${EVALUATION_LINK_BASEURL:-}
     volumes:
       - app_static:/app/static
+      - app_well_known:/app/web/static/.well-known
       - app_socket:/socket
       - ${KELVIN__LOCAL_SETTINGS_PATH}:/app/kelvin/local_settings.py:ro
       - ${UWSGI__CONFIG_PATH}:/app/uwsgi.ini:ro
@@ -77,6 +78,7 @@ services:
       - ${NGINX__CERTS_PATH}:/etc/nginx/certs:ro
       - ${NGINX__LOGS_PATH}:/var/log/nginx
       - app_static:/app/static:ro
+      - app_well_known:/app/.well-known:ro
       - app_socket:/socket
     networks:
       default:
@@ -220,6 +222,7 @@ services:
 
 volumes:
   app_static:
+  app_well_known:
   app_socket:
 
 networks:

--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -1,1 +1,3 @@
-If you find a security vulnerability in Kelvin, please disclose it to kelvin@vsb.cz. Thank you!
+Contact: mailto:kelvin@vsb.cz
+Expires: 2036-01-01T00:00:00Z
+Preferred-Languages: en, cs

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.conf.urls.static import static
 
 from .views import common as common_view
 from .views import notification as notification_view
@@ -163,4 +164,4 @@ urlpatterns = [
     path("teacher/quiz/scoring/<int:enrolled_id>", teacher_view.quiz_scoring, name="quiz_scoring"),
     path("teacher/quizzes", teacher_view.quiz_list, name="quiz_list"),
     path("teacher/quiz/<int:quiz_id>/submits", teacher_view.quiz_submits, name="quiz_submits"),
-]
+] + static("/.well-known", document_root="web/static/.well-known")


### PR DESCRIPTION
Even though `.well-known/security.txt` file was added (#760), it was never accessible on that path, not even locally. I added a static URL pattern to cover `.well-known` directory. For nginx, I added a new volume with static data and modified the config, since `collectstatic` won't include this file, no matter it's present in the static directory.

Additionally, I modified the content of `security.txt` file to comply with [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).