### PR TITLE
Fix submit comments not updating value

### DIFF
--- a/frontend/src/Quiz/QuizEdit.vue
+++ b/frontend/src/Quiz/QuizEdit.vue
@@ -795,7 +795,7 @@ onUnmounted(() => {
           >
             <div class="col-12">
               <Editor
-                v-model:value="currentQuestionYamlRef"
+                v-model="currentQuestionYamlRef"
                 filename="quiz.yaml"
                 :extensions="[extension]"
                 :lint="true"

--- a/frontend/src/components/submit/CommentForm.vue
+++ b/frontend/src/components/submit/CommentForm.vue
@@ -33,7 +33,7 @@ const submit = () => {
 
 <template>
   <Editor
-    v-model:value="localComment"
+    v-model="localComment"
     filename="comment.md"
     :disabled="disabled"
     :wrap="true"


### PR DESCRIPTION
Some students reported that comments submitted via the Vue comment component are not sent because the API request sends an empty message. I noticed that `CommentForm` and `QuizEdit` components are the only ones using `v-model:value` for `Editor` component instead of `v-model`. Since we don't use multiple bindings here, I think the default one is sufficient and fixes the problem.