### PR TITLE
Create LLM prompt editor

### DIFF
--- a/api/v2/llm/prompt.py
+++ b/api/v2/llm/prompt.py
@@ -8,7 +8,12 @@ from serde import to_dict
 from api.auth import require_auth_token
 from common.models import LlmReviewPrompt
 from common.utils import is_teacher
-from .schema import PromptResponse, PromptCreateRequest, PromptUpdateRequest
+from .schema import (
+    PromptResponse,
+    PromptCreateRequest,
+    PromptUpdateRequest,
+    PromptDescriptionUpdateRequest,
+)
 
 router = Router()
 
@@ -132,23 +137,18 @@ def create_prompt(request, payload: PromptCreateRequest):
     )
 
     prompt = LlmReviewPrompt.objects.select_related("author", "updated_by").get(id=prompt.id)
-    return 201, prompt_to_response(prompt)
+    return prompt_to_response(prompt)
 
 
 @router.put(
     "/{prompt_name}",
-    description="Update a prompt by creating a new version. Targets the latest version by name.",
+    description="Update a prompt's text by creating a new version. Name is immutable.",
 )
 @user_passes_test(is_teacher)
 @transaction.atomic
 def update_prompt(request, prompt_name: str, payload: PromptUpdateRequest):
     prompt = get_latest_prompt(prompt_name)
     check_prompt_permission(request.user, prompt)
-
-    new_name = payload.name if payload.name is not None else prompt.name
-    if new_name.lower() != prompt.name.lower():
-        if LlmReviewPrompt.objects.filter(name__iexact=new_name).exists():
-            raise HttpError(400, f"A prompt with name '{new_name}' already exists.")
 
     latest_version = (
         LlmReviewPrompt.objects.filter(name=prompt.name).aggregate(max_version=Max("version"))[
@@ -158,8 +158,8 @@ def update_prompt(request, prompt_name: str, payload: PromptUpdateRequest):
     )
 
     new_prompt = LlmReviewPrompt.objects.create(
-        name=new_name,
-        description=payload.description if payload.description is not None else prompt.description,
+        name=prompt.name,
+        description=prompt.description,
         text=payload.text if payload.text is not None else prompt.text,
         default=prompt.default,
         version=latest_version + 1,
@@ -171,7 +171,21 @@ def update_prompt(request, prompt_name: str, payload: PromptUpdateRequest):
     new_prompt = LlmReviewPrompt.objects.select_related("author", "updated_by").get(
         id=new_prompt.id
     )
-    return 201, prompt_to_response(new_prompt)
+    return prompt_to_response(new_prompt)
+
+
+@router.patch(
+    "/{prompt_name}",
+    description="Update the description of the latest prompt version without creating a new version.",
+)
+@user_passes_test(is_teacher)
+def update_prompt_description(request, prompt_name: str, payload: PromptDescriptionUpdateRequest):
+    prompt = get_latest_prompt(prompt_name)
+    check_prompt_permission(request.user, prompt)
+
+    LlmReviewPrompt.objects.filter(id=prompt.id).update(description=payload.description)
+    prompt.refresh_from_db()
+    return prompt_to_response(prompt)
 
 
 @router.delete(

--- a/api/v2/llm/prompt.py
+++ b/api/v2/llm/prompt.py
@@ -1,24 +1,229 @@
+from django.contrib.auth.decorators import user_passes_test
+from django.db import transaction
+from django.db.models import Max, Subquery, OuterRef
 from ninja import Router
 from ninja.errors import HttpError
 from serde import to_dict
 
 from api.auth import require_auth_token
 from common.models import LlmReviewPrompt
+from common.utils import is_teacher
+from .schema import PromptResponse, PromptCreateRequest, PromptUpdateRequest
 
 router = Router()
+
+
+def prompt_to_response(prompt: LlmReviewPrompt) -> PromptResponse:
+    return PromptResponse(
+        id=prompt.id,
+        name=prompt.name,
+        description=prompt.description or "",
+        version=prompt.version,
+        text=prompt.text,
+        created_at=prompt.created_at,
+        updated_at=prompt.created_at,
+        default=prompt.default,
+        is_deleted=prompt.is_deleted,
+        author_username=prompt.author.username if prompt.author else None,
+        author_full_name=prompt.author.get_full_name() if prompt.author else None,
+        updated_by_username=prompt.updated_by.username if prompt.updated_by else None,
+        updated_by_full_name=prompt.updated_by.get_full_name() if prompt.updated_by else None,
+    )
+
+
+def check_prompt_permission(user, prompt: LlmReviewPrompt) -> None:
+    """Superuser can always modify; teacher only their own prompts."""
+    if user.is_superuser:
+        return
+
+    if prompt.author_id != user.id:
+        raise HttpError(403, "You do not have permission to modify this prompt.")
+
+
+def get_latest_prompt(prompt_name: str) -> LlmReviewPrompt:
+    """Get the latest version of a prompt by name (case-insensitive)."""
+    prompt = (
+        LlmReviewPrompt.objects.filter(name__iexact=prompt_name)
+        .select_related("author", "updated_by")
+        .order_by("-version")
+        .first()
+    )
+
+    if not prompt:
+        raise HttpError(404, "Prompt not found.")
+
+    return prompt
 
 
 @router.get(
     "/{prompt_name}",
     url_name="retrieve_llm_review_prompt",
-    summary="Retrieve LLM Review Prompt",
     description="Retrieve the most recent LLM review prompt by name.",
 )
 @require_auth_token
 def retrieve_llm_review_prompt(request, prompt_name: str):
-    prompt = LlmReviewPrompt.objects.filter(name=prompt_name).order_by("version").first()
+    prompt = LlmReviewPrompt.objects.filter(name__iexact=prompt_name).order_by("version").first()
 
     if not prompt:
         return HttpError(404, f"LLM Review Prompt with name '{prompt_name}' not found.")
 
     return to_dict(prompt.to_dto())
+
+
+@router.get(
+    "/",
+    description="List latest version of each prompt. show_deleted includes own deleted prompts (superusers see all deleted).",
+)
+@user_passes_test(is_teacher)
+def list_prompts(request, show_deleted: bool = False):
+    from django.db.models import Q
+
+    latest_version = (
+        LlmReviewPrompt.objects.filter(name=OuterRef("name")).order_by("-version").values("id")[:1]
+    )
+
+    prompts = LlmReviewPrompt.objects.filter(id__in=Subquery(latest_version))
+
+    if show_deleted:
+        if request.user.is_superuser:
+            pass  # show everything
+        else:
+            # show non-deleted + own deleted
+            prompts = prompts.filter(Q(is_deleted=False) | Q(author=request.user))
+    else:
+        prompts = prompts.filter(is_deleted=False)
+
+    prompts = prompts.select_related("author", "updated_by").order_by("name")
+    return [prompt_to_response(p) for p in prompts]
+
+
+@router.get(
+    "/name/{prompt_name}/versions",
+    description="Get all versions of a prompt by name.",
+)
+@user_passes_test(is_teacher)
+def get_prompt_versions(request, prompt_name: str):
+    prompts = (
+        LlmReviewPrompt.objects.filter(name__iexact=prompt_name)
+        .select_related("author", "updated_by")
+        .order_by("-version")
+    )
+
+    return [prompt_to_response(p) for p in prompts]
+
+
+@router.post(
+    "/",
+    description="Create a new prompt (version 1).",
+)
+@user_passes_test(is_teacher)
+def create_prompt(request, payload: PromptCreateRequest):
+    existing = LlmReviewPrompt.objects.filter(name__iexact=payload.name).exists()
+    if existing:
+        raise HttpError(400, f"A prompt with name '{payload.name}' already exists.")
+
+    prompt = LlmReviewPrompt.objects.create(
+        name=payload.name,
+        description=payload.description,
+        text=payload.text,
+        version=1,
+        author=request.user,
+        updated_by=request.user,
+    )
+
+    prompt = LlmReviewPrompt.objects.select_related("author", "updated_by").get(id=prompt.id)
+    return 201, prompt_to_response(prompt)
+
+
+@router.put(
+    "/{prompt_name}",
+    description="Update a prompt by creating a new version. Targets the latest version by name.",
+)
+@user_passes_test(is_teacher)
+@transaction.atomic
+def update_prompt(request, prompt_name: str, payload: PromptUpdateRequest):
+    prompt = get_latest_prompt(prompt_name)
+    check_prompt_permission(request.user, prompt)
+
+    new_name = payload.name if payload.name is not None else prompt.name
+    if new_name.lower() != prompt.name.lower():
+        if LlmReviewPrompt.objects.filter(name__iexact=new_name).exists():
+            raise HttpError(400, f"A prompt with name '{new_name}' already exists.")
+
+    latest_version = (
+        LlmReviewPrompt.objects.filter(name=prompt.name).aggregate(max_version=Max("version"))[
+            "max_version"
+        ]
+        or 0
+    )
+
+    new_prompt = LlmReviewPrompt.objects.create(
+        name=new_name,
+        description=payload.description if payload.description is not None else prompt.description,
+        text=payload.text if payload.text is not None else prompt.text,
+        default=prompt.default,
+        version=latest_version + 1,
+        author=prompt.author,
+        updated_by=request.user,
+        is_deleted=prompt.is_deleted,
+    )
+
+    new_prompt = LlmReviewPrompt.objects.select_related("author", "updated_by").get(
+        id=new_prompt.id
+    )
+    return 201, prompt_to_response(new_prompt)
+
+
+@router.delete(
+    "/{prompt_name}",
+    description="Mark a prompt as deleted (soft delete). All versions are marked. Targets by name.",
+)
+@user_passes_test(is_teacher)
+def delete_prompt(request, prompt_name: str):
+    prompt = get_latest_prompt(prompt_name)
+    check_prompt_permission(request.user, prompt)
+
+    if prompt.default:
+        raise HttpError(
+            400, "Cannot delete the default prompt. Set another prompt as default first."
+        )
+
+    LlmReviewPrompt.objects.filter(name=prompt.name).update(is_deleted=True)
+    return {"status": "deleted"}
+
+
+@router.patch(
+    "/{prompt_name}/restore",
+    description="Restore a soft-deleted prompt. Teachers can restore their own; superusers can restore any.",
+)
+@user_passes_test(is_teacher)
+def restore_prompt(request, prompt_name: str):
+    prompt = get_latest_prompt(prompt_name)
+    check_prompt_permission(request.user, prompt)
+
+    LlmReviewPrompt.objects.filter(name=prompt.name).update(is_deleted=False)
+    return {"status": "restored"}
+
+
+@router.patch(
+    "/{prompt_name}/toggle-default",
+    description="Set a prompt as the default. Only superusers can do this. Targets by name.",
+)
+@user_passes_test(is_teacher)
+@transaction.atomic
+def toggle_default(request, prompt_name: str):
+    if not request.user.is_superuser:
+        raise HttpError(403, "Only superadmins can set the default prompt.")
+
+    prompt = get_latest_prompt(prompt_name)
+
+    if prompt.default:
+        raise HttpError(
+            400, "Cannot unset the default prompt. Set another prompt as default first."
+        )
+
+    LlmReviewPrompt.objects.all().update(default=False)
+    LlmReviewPrompt.objects.filter(name=prompt.name).update(default=True)
+
+    prompt.refresh_from_db()
+    return prompt_to_response(prompt)

--- a/api/v2/llm/schema.py
+++ b/api/v2/llm/schema.py
@@ -1,6 +1,8 @@
+import re
 from datetime import datetime
 
 from ninja import Schema
+from pydantic import field_validator
 
 
 class ModifySuggestionSchema(Schema):
@@ -32,8 +34,19 @@ class PromptCreateRequest(Schema):
     description: str = ""
     text: str
 
+    @field_validator("name")
+    @classmethod
+    def name_must_be_snake_case(cls, v: str) -> str:
+        if not re.fullmatch(r"[a-z][a-z0-9_]*", v):
+            raise ValueError(
+                "Prompt name must be snake_case (lowercase letters, digits, and underscores, starting with a letter)."
+            )
+        return v
+
 
 class PromptUpdateRequest(Schema):
-    name: str | None = None
-    description: str | None = None
     text: str | None = None
+
+
+class PromptDescriptionUpdateRequest(Schema):
+    description: str

--- a/api/v2/llm/schema.py
+++ b/api/v2/llm/schema.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from ninja import Schema
 
 
@@ -7,3 +9,31 @@ class ModifySuggestionSchema(Schema):
 
 class RateSuggestionSchema(Schema):
     rating: int
+
+
+class PromptResponse(Schema):
+    id: int
+    name: str
+    description: str
+    version: int
+    text: str
+    created_at: datetime | None
+    updated_at: datetime | None
+    default: bool
+    is_deleted: bool
+    author_username: str | None
+    author_full_name: str | None
+    updated_by_username: str | None
+    updated_by_full_name: str | None
+
+
+class PromptCreateRequest(Schema):
+    name: str
+    description: str = ""
+    text: str
+
+
+class PromptUpdateRequest(Schema):
+    name: str | None = None
+    description: str | None = None
+    text: str | None = None

--- a/common/migrations/0034_add_prompt_editor_fields.py
+++ b/common/migrations/0034_add_prompt_editor_fields.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("common", "0033_remove_email_sent_at_email_sent_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="llmreviewprompt",
+            name="author",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="authored_prompts",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="llmreviewprompt",
+            name="updated_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="updated_prompts",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="llmreviewprompt",
+            name="is_deleted",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/common/models.py
+++ b/common/models.py
@@ -381,6 +381,21 @@ class LlmReviewPrompt(models.Model):
     text = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
     default = models.BooleanField(default=False)
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="authored_prompts",
+    )
+    updated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="updated_prompts",
+    )
+    is_deleted = models.BooleanField(default=False)
 
     def to_dto(self) -> LlmReviewPromptDTO:
         return LlmReviewPromptDTO(

--- a/frontend/src/Teacher/PromptEditor.vue
+++ b/frontend/src/Teacher/PromptEditor.vue
@@ -1,0 +1,595 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { getFromAPI, getDataWithCSRF } from '../utilities/api';
+import { toastApi } from '../utilities/toast';
+import Editor from '../components/Editor.vue';
+import VueModal from '../components/VueModal.vue';
+
+type Prompt = {
+  id: number;
+  name: string;
+  description: string;
+  version: number;
+  text: string;
+  created_at: string | null;
+  updated_at: string | null;
+  default: boolean;
+  is_deleted: boolean;
+  author_username: string | null;
+  author_full_name: string | null;
+  updated_by_username: string | null;
+  updated_by_full_name: string | null;
+};
+
+const props = defineProps<{
+  isSuperAdmin: boolean;
+  username: string;
+}>();
+
+const API = '/api/v2/llm/prompt';
+
+const prompts = ref<Prompt[]>([]);
+const selectedPrompt = ref<Prompt | null>(null);
+const versionsForName = ref<string | null>(null);
+const versions = ref<Prompt[]>([]);
+const selectedVersionId = ref<number | null>(null);
+const showDeleted = ref(false);
+const loading = ref(false);
+const saving = ref(false);
+
+const editName = ref('');
+const editDescription = ref('');
+const editText = ref('');
+
+const isCreating = ref(false);
+
+const showDeleteModal = ref(false);
+const promptToDelete = ref<Prompt | null>(null);
+
+// Ownership: teacher owns selected prompt, or is superadmin
+const isOwner = computed(() => {
+  if (isCreating.value) return true;
+  if (!selectedPrompt.value) return false;
+  if (props.isSuperAdmin) return true;
+  return selectedPrompt.value.author_username === props.username;
+});
+
+const isLatestVersion = computed(() => {
+  if (!selectedPrompt.value) return true;
+  if (versionsForName.value !== selectedPrompt.value.name) return true;
+  if (versions.value.length === 0) return true;
+  return selectedPrompt.value.id === versions.value[0]?.id;
+});
+
+const canEdit = computed(() => {
+  if (isCreating.value) return true;
+  if (!selectedPrompt.value) return false;
+  if (!isOwner.value) return false;
+  return isLatestVersion.value;
+});
+
+const canDelete = computed(() => {
+  if (!selectedPrompt.value) return false;
+  if (selectedPrompt.value.default) return false;
+  if (selectedPrompt.value.is_deleted) return false;
+  if (!isOwner.value) return false;
+  return true;
+});
+
+const myPrompts = computed(() => prompts.value.filter((p) => p.author_username === props.username));
+
+const otherPrompts = computed(() =>
+  prompts.value.filter((p) => p.author_username !== props.username)
+);
+
+async function loadPrompts() {
+  loading.value = true;
+  const params = new URLSearchParams();
+
+  if (showDeleted.value) {
+    params.append('show_deleted', 'true');
+  }
+
+  const data = await getFromAPI<Prompt[]>(`${API}/?${params.toString()}`);
+  if (data) {
+    prompts.value = data;
+
+    if (selectedPrompt.value) {
+      const refreshed = data.find((p) => p.name === selectedPrompt.value!.name);
+
+      if (refreshed) {
+        selectedPrompt.value = {
+          ...selectedPrompt.value,
+          default: refreshed.default,
+          is_deleted: refreshed.is_deleted
+        };
+      }
+    }
+  }
+
+  loading.value = false;
+}
+
+async function loadVersions(promptName: string) {
+  const data = await getFromAPI<Prompt[]>(`${API}/name/${encodeURIComponent(promptName)}/versions`);
+
+  if (data) {
+    versions.value = data;
+    versionsForName.value = promptName;
+  }
+}
+
+function selectPrompt(prompt: Prompt) {
+  versions.value = [];
+  versionsForName.value = null;
+  selectedPrompt.value = prompt;
+  isCreating.value = false;
+  editName.value = prompt.name;
+  editDescription.value = prompt.description;
+  editText.value = prompt.text;
+  selectedVersionId.value = prompt.id;
+  loadVersions(prompt.name);
+}
+
+function switchVersion() {
+  const version = versions.value.find((v) => v.id === selectedVersionId.value);
+
+  if (version) {
+    selectedPrompt.value = version;
+    editName.value = version.name;
+    editDescription.value = version.description;
+    editText.value = version.text;
+  }
+}
+
+function startCreate() {
+  isCreating.value = true;
+  selectedPrompt.value = null;
+  selectedVersionId.value = null;
+  versions.value = [];
+  versionsForName.value = null;
+  editName.value = '';
+  editDescription.value = '';
+  editText.value = '';
+}
+
+function clonePrompt(prompt: Prompt) {
+  isCreating.value = true;
+  selectedPrompt.value = null;
+  selectedVersionId.value = null;
+  versions.value = [];
+  versionsForName.value = null;
+  editName.value = prompt.name + ' (copy)';
+  editDescription.value = prompt.description;
+  editText.value = prompt.text;
+}
+
+async function savePrompt() {
+  saving.value = true;
+
+  if (!editName.value.trim()) {
+    toastApi.warning('Name is required.');
+    saving.value = false;
+    return;
+  }
+
+  if (!editText.value.trim()) {
+    toastApi.warning('Prompt text is required.');
+    saving.value = false;
+    return;
+  }
+
+  if (isCreating.value) {
+    const result = await getDataWithCSRF<Prompt>(
+      `${API}/`,
+      'POST',
+      {
+        name: editName.value.trim(),
+        description: editDescription.value,
+        text: editText.value
+      },
+      { 'Content-Type': 'application/json' }
+    );
+
+    if (result) {
+      toastApi.success('Prompt created successfully.');
+      isCreating.value = false;
+      await loadPrompts();
+      selectPrompt(result);
+    } else {
+      toastApi.error('Failed to create prompt. A prompt with this name may already exist.');
+    }
+  } else if (selectedPrompt.value) {
+    const result = await getDataWithCSRF<Prompt>(
+      `${API}/${encodeURIComponent(selectedPrompt.value.name)}`,
+      'PUT',
+      {
+        name: editName.value.trim(),
+        description: editDescription.value,
+        text: editText.value
+      },
+      { 'Content-Type': 'application/json' }
+    );
+
+    if (result) {
+      toastApi.success(`Prompt saved as version ${result.version}.`);
+      await loadPrompts();
+      selectPrompt(result);
+    } else {
+      toastApi.error('Failed to update prompt.');
+    }
+  }
+
+  saving.value = false;
+}
+
+function confirmDelete(prompt: Prompt) {
+  promptToDelete.value = prompt;
+  showDeleteModal.value = true;
+}
+
+async function handleDeleteModalClose(proceed: boolean) {
+  showDeleteModal.value = false;
+
+  if (proceed && promptToDelete.value) {
+    await deletePrompt(promptToDelete.value);
+  }
+
+  promptToDelete.value = null;
+}
+
+async function deletePrompt(prompt: Prompt) {
+  const result = await getDataWithCSRF<{ status: string }>(
+    `${API}/${encodeURIComponent(prompt.name)}`,
+    'DELETE'
+  );
+
+  if (result) {
+    toastApi.success('Prompt deleted.');
+    selectedPrompt.value = null;
+    isCreating.value = false;
+    versions.value = [];
+    versionsForName.value = null;
+    await loadPrompts();
+  } else {
+    toastApi.error('Failed to delete prompt.');
+  }
+}
+
+async function restorePrompt(prompt: Prompt) {
+  const result = await getDataWithCSRF<{ status: string }>(
+    `${API}/${encodeURIComponent(prompt.name)}/restore`,
+    'PATCH'
+  );
+
+  if (result) {
+    toastApi.success('Prompt restored.');
+    await loadPrompts();
+  } else {
+    toastApi.error('Failed to restore prompt.');
+  }
+}
+
+async function setDefault(prompt: Prompt) {
+  if (prompt.default) return;
+
+  const result = await getDataWithCSRF<Prompt>(
+    `${API}/${encodeURIComponent(prompt.name)}/toggle-default`,
+    'PATCH'
+  );
+
+  if (result) {
+    await loadPrompts();
+  } else {
+    toastApi.error('Failed to set default prompt.');
+  }
+}
+
+function formatDate(date: string | null): string {
+  if (!date) return '-';
+  return new Date(date).toLocaleString();
+}
+
+onMounted(() => {
+  loadPrompts();
+});
+</script>
+
+<template>
+  <div class="prompt-editor">
+    <div class="row g-0" style="min-height: 50vh">
+      <!-- Left panel: Prompt list -->
+      <div class="col-md-4 col-lg-3 border-end">
+        <div class="p-3">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5 class="mb-0">Prompts</h5>
+
+            <button class="btn btn-sm btn-primary" @click="startCreate">
+              <i class="bi bi-plus-lg"></i> New
+            </button>
+          </div>
+
+          <!-- Show deleted toggle -->
+          <div class="form-check mb-3">
+            <input
+              id="showDeleted"
+              v-model="showDeleted"
+              class="form-check-input"
+              type="checkbox"
+              @change="loadPrompts"
+            />
+            <label class="form-check-label" for="showDeleted"> Show deleted </label>
+          </div>
+
+          <div v-if="loading" class="text-center py-3">
+            <div class="spinner-border spinner-border-sm" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </div>
+
+          <div v-else-if="prompts.length === 0" class="text-muted small py-2">
+            No prompts found.
+          </div>
+
+          <template v-else>
+            <!-- My prompts -->
+            <div v-if="myPrompts.length > 0" class="mb-3">
+              <div class="text-muted small fw-semibold text-uppercase mb-1">My Prompts</div>
+
+              <div class="list-group">
+                <button
+                  v-for="prompt in myPrompts"
+                  :key="prompt.id"
+                  class="list-group-item list-group-item-action d-flex align-items-center py-2"
+                  :class="{
+                    active: selectedPrompt?.name === prompt.name && !isCreating,
+                    'list-group-item-danger': prompt.is_deleted
+                  }"
+                  @click="selectPrompt(prompt)"
+                >
+                  <span class="text-truncate me-auto fw-semibold">{{ prompt.name }}</span>
+                  <span class="badge bg-secondary ms-2">v{{ prompt.version }}</span>
+                  <span v-if="prompt.default" class="badge bg-success ms-1">Default</span>
+                  <span v-if="prompt.is_deleted" class="badge bg-danger ms-1">Deleted</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Other prompts -->
+            <div v-if="otherPrompts.length > 0">
+              <div class="text-muted small fw-semibold text-uppercase mb-1">Other Prompts</div>
+
+              <div class="list-group">
+                <button
+                  v-for="prompt in otherPrompts"
+                  :key="prompt.id"
+                  class="list-group-item list-group-item-action d-flex align-items-center py-2"
+                  :class="{
+                    active: selectedPrompt?.name === prompt.name && !isCreating,
+                    'list-group-item-danger': prompt.is_deleted
+                  }"
+                  @click="selectPrompt(prompt)"
+                >
+                  <span class="text-truncate me-auto fw-semibold">{{ prompt.name }}</span>
+                  <span class="badge bg-secondary ms-2">v{{ prompt.version }}</span>
+                  <span v-if="prompt.default" class="badge bg-success ms-1">Default</span>
+                  <span v-if="prompt.is_deleted" class="badge bg-danger ms-1">Deleted</span>
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- Right panel: Editor -->
+      <div class="col-md-8 col-lg-9 d-flex flex-column">
+        <div class="p-3 d-flex flex-column flex-grow-1">
+          <!-- No selection state -->
+          <div
+            v-if="!selectedPrompt && !isCreating"
+            class="d-flex align-items-center justify-content-center flex-grow-1"
+          >
+            <div class="text-center text-muted">
+              <i class="bi bi-pencil-square" style="font-size: 3rem"></i>
+              <p class="mt-2">Select a prompt from the list or create a new one.</p>
+            </div>
+          </div>
+
+          <!-- Editor form -->
+          <div v-else class="d-flex flex-column flex-grow-1">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <h5 class="mb-0">
+                {{ isCreating ? 'New Prompt' : `Edit: ${selectedPrompt?.name}` }}
+              </h5>
+
+              <div v-if="!isCreating && selectedPrompt" class="d-flex gap-2 align-items-center">
+                <!-- Version selector -->
+                <div class="d-flex align-items-center gap-1">
+                  <label class="form-label mb-0 small">Version:</label>
+                  <select
+                    v-model="selectedVersionId"
+                    class="form-select form-select-sm"
+                    style="width: auto"
+                    :disabled="versions.length <= 1"
+                    @change="switchVersion"
+                  >
+                    <option v-if="versions.length === 0" :value="selectedPrompt.id">
+                      v{{ selectedPrompt.version }} (latest)
+                    </option>
+                    <option v-for="v in versions" :key="v.id" :value="v.id">
+                      v{{ v.version }}{{ v.id === versions[0]?.id ? ' (latest)' : '' }}
+                    </option>
+                  </select>
+                </div>
+
+                <!-- Clone as new prompt -->
+                <button
+                  class="btn btn-sm btn-outline-secondary"
+                  title="Clone as new prompt"
+                  @click="clonePrompt(selectedPrompt)"
+                >
+                  <i class="bi bi-files"></i>
+                </button>
+
+                <!-- Set as default (superadmin only) -->
+                <button
+                  v-if="isSuperAdmin"
+                  class="btn btn-sm"
+                  :class="selectedPrompt.default ? 'btn-warning' : 'btn-outline-warning'"
+                  :title="selectedPrompt.default ? 'This is the default prompt' : 'Set as default'"
+                  :disabled="selectedPrompt.default"
+                  @click="setDefault(selectedPrompt)"
+                >
+                  <i class="bi" :class="selectedPrompt.default ? 'bi-star-fill' : 'bi-star'"></i>
+                </button>
+
+                <!-- Delete: always shown, disabled when not allowed -->
+                <button
+                  v-if="!selectedPrompt.is_deleted"
+                  class="btn btn-sm btn-outline-danger"
+                  :title="
+                    !isOwner
+                      ? 'You can only delete your own prompts'
+                      : selectedPrompt.default
+                        ? 'Cannot delete the default prompt'
+                        : 'Delete prompt'
+                  "
+                  :disabled="!canDelete"
+                  @click="confirmDelete(selectedPrompt)"
+                >
+                  <i class="bi bi-trash"></i>
+                </button>
+
+                <!-- Restore (superadmin only) -->
+                <button
+                  v-if="selectedPrompt.is_deleted && isOwner"
+                  class="btn btn-sm btn-outline-success"
+                  title="Restore prompt"
+                  @click="restorePrompt(selectedPrompt)"
+                >
+                  <i class="bi bi-arrow-counterclockwise"></i> Restore
+                </button>
+              </div>
+            </div>
+
+            <!-- Metadata -->
+            <div v-if="selectedPrompt && !isCreating" class="mb-3 small text-muted">
+              <span v-if="selectedPrompt.author_full_name">
+                Author: <strong>{{ selectedPrompt.author_full_name }}</strong>
+              </span>
+
+              <span v-if="selectedPrompt.created_at">
+                &middot; Created: {{ formatDate(selectedPrompt.created_at) }}
+              </span>
+
+              <span v-if="selectedPrompt.updated_by_full_name">
+                &middot; Updated by: <strong>{{ selectedPrompt.updated_by_full_name }}</strong>
+              </span>
+
+              <span v-if="selectedPrompt.updated_at">
+                at {{ formatDate(selectedPrompt.updated_at) }}
+              </span>
+            </div>
+
+            <!-- Not-owner notice -->
+            <div v-if="!isOwner && !isCreating" class="alert alert-info small">
+              <i class="bi bi-info-circle"></i>
+              This prompt belongs to another user. You cannot edit it.
+            </div>
+
+            <!-- Not latest version warning -->
+            <div
+              v-if="isOwner && !isLatestVersion && !isCreating"
+              class="alert alert-warning small"
+            >
+              <i class="bi bi-exclamation-triangle"></i>
+              You are viewing an older version (v{{ selectedPrompt?.version }}). Switch to the
+              latest version to make edits.
+            </div>
+
+            <!-- Form -->
+            <div class="mb-3">
+              <label class="form-label">Name</label>
+
+              <input
+                v-model="editName"
+                type="text"
+                class="form-control"
+                :disabled="!canEdit"
+                placeholder="Prompt name"
+              />
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Description</label>
+
+              <textarea
+                v-model="editDescription"
+                class="form-control"
+                :disabled="!canEdit"
+                rows="2"
+                placeholder="Optional description"
+              ></textarea>
+            </div>
+
+            <div class="mb-3 prompt-text-wrapper">
+              <label class="form-label">Prompt Text</label>
+
+              <Editor v-model="editText" filename="prompt.md" :disabled="!canEdit" :wrap="true" />
+            </div>
+
+            <div class="d-flex gap-2">
+              <button class="btn btn-primary" :disabled="!canEdit || saving" @click="savePrompt">
+                <span v-if="saving" class="spinner-border spinner-border-sm me-1"></span>
+                {{ isCreating ? 'Create Prompt' : 'Save as New Version' }}
+              </button>
+
+              <button
+                v-if="isCreating"
+                class="btn btn-secondary"
+                @click="
+                  isCreating = false;
+                  selectedPrompt = null;
+                "
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete confirmation modal -->
+    <VueModal
+      :open="showDeleteModal"
+      title="Delete Prompt"
+      cancel-button-label="Cancel"
+      proceed-button-label="Delete"
+      :on-closed="handleDeleteModalClose"
+    >
+      <p>
+        Are you sure you want to delete <strong>{{ promptToDelete?.name }}</strong
+        >?
+      </p>
+      <p class="text-muted small">The prompt will be soft-deleted and can be restored later.</p>
+    </VueModal>
+  </div>
+</template>
+
+<style scoped>
+.prompt-editor {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.375rem;
+  background: var(--bs-body-bg);
+}
+
+.list-group-item.active {
+  z-index: 1;
+}
+
+/* 20 lines at ~18px line-height = 360px */
+.prompt-text-wrapper :deep(.CodeMirror) {
+  height: 360px;
+}
+</style>

--- a/frontend/src/Teacher/PromptEditor.vue
+++ b/frontend/src/Teacher/PromptEditor.vue
@@ -36,6 +36,7 @@ const selectedVersionId = ref<number | null>(null);
 const showDeleted = ref(false);
 const loading = ref(false);
 const saving = ref(false);
+const saveAttempted = ref(false);
 
 const editName = ref('');
 const editDescription = ref('');
@@ -66,6 +67,23 @@ const canEdit = computed(() => {
   if (!selectedPrompt.value) return false;
   if (!isOwner.value) return false;
   return isLatestVersion.value;
+});
+
+const canEditName = computed(() => isCreating.value);
+
+const descriptionChanged = computed(
+  () => !!selectedPrompt.value && editDescription.value !== selectedPrompt.value.description
+);
+
+const textChanged = computed(
+  () => !!selectedPrompt.value && editText.value !== selectedPrompt.value.text
+);
+
+const saveLabel = computed(() => {
+  if (isCreating.value) return 'Create Prompt';
+  if (textChanged.value) return 'Save as New Version';
+  if (descriptionChanged.value) return 'Update Description';
+  return 'Save';
 });
 
 const canDelete = computed(() => {
@@ -124,6 +142,7 @@ function selectPrompt(prompt: Prompt) {
   versionsForName.value = null;
   selectedPrompt.value = prompt;
   isCreating.value = false;
+  saveAttempted.value = false;
   editName.value = prompt.name;
   editDescription.value = prompt.description;
   editText.value = prompt.text;
@@ -148,6 +167,7 @@ function startCreate() {
   selectedVersionId.value = null;
   versions.value = [];
   versionsForName.value = null;
+  saveAttempted.value = false;
   editName.value = '';
   editDescription.value = '';
   editText.value = '';
@@ -164,8 +184,9 @@ function clonePrompt(prompt: Prompt) {
   editText.value = prompt.text;
 }
 
-async function savePrompt() {
+async function save() {
   saving.value = true;
+  saveAttempted.value = true;
 
   if (!editName.value.trim()) {
     toastApi.warning('Name is required.');
@@ -173,8 +194,15 @@ async function savePrompt() {
     return;
   }
 
+  if (isCreating.value && !/^[a-z][a-z0-9_]*$/.test(editName.value.trim())) {
+    toastApi.warning(
+      'Name must be snake_case (lowercase letters, digits, and underscores, starting with a letter).'
+    );
+    saving.value = false;
+    return;
+  }
+
   if (!editText.value.trim()) {
-    toastApi.warning('Prompt text is required.');
     saving.value = false;
     return;
   }
@@ -200,23 +228,46 @@ async function savePrompt() {
       toastApi.error('Failed to create prompt. A prompt with this name may already exist.');
     }
   } else if (selectedPrompt.value) {
-    const result = await getDataWithCSRF<Prompt>(
-      `${API}/${encodeURIComponent(selectedPrompt.value.name)}`,
-      'PUT',
-      {
-        name: editName.value.trim(),
-        description: editDescription.value,
-        text: editText.value
-      },
-      { 'Content-Type': 'application/json' }
-    );
+    if (textChanged.value) {
+      // If description also changed, persist it first so the new version inherits it.
+      if (descriptionChanged.value) {
+        await getDataWithCSRF<Prompt>(
+          `${API}/${encodeURIComponent(selectedPrompt.value.name)}`,
+          'PATCH',
+          { description: editDescription.value },
+          { 'Content-Type': 'application/json' }
+        );
+      }
 
-    if (result) {
-      toastApi.success(`Prompt saved as version ${result.version}.`);
-      await loadPrompts();
-      selectPrompt(result);
-    } else {
-      toastApi.error('Failed to update prompt.');
+      const result = await getDataWithCSRF<Prompt>(
+        `${API}/${encodeURIComponent(selectedPrompt.value.name)}`,
+        'PUT',
+        { text: editText.value },
+        { 'Content-Type': 'application/json' }
+      );
+
+      if (result) {
+        toastApi.success(`Prompt saved as version ${result.version}.`);
+        await loadPrompts();
+        selectPrompt(result);
+      } else {
+        toastApi.error('Failed to update prompt.');
+      }
+    } else if (descriptionChanged.value) {
+      const result = await getDataWithCSRF<Prompt>(
+        `${API}/${encodeURIComponent(selectedPrompt.value.name)}`,
+        'PATCH',
+        { description: editDescription.value },
+        { 'Content-Type': 'application/json' }
+      );
+
+      if (result) {
+        toastApi.success('Description updated.');
+        selectedPrompt.value = { ...selectedPrompt.value, description: result.description };
+        await loadPrompts();
+      } else {
+        toastApi.error('Failed to update description.');
+      }
     }
   }
 
@@ -515,9 +566,22 @@ onMounted(() => {
                 v-model="editName"
                 type="text"
                 class="form-control"
-                :disabled="!canEdit"
-                placeholder="Prompt name"
+                :class="{
+                  'is-invalid': isCreating && editName && !/^[a-z][a-z0-9_]*$/.test(editName)
+                }"
+                :disabled="!canEditName"
+                placeholder="my_prompt_name"
               />
+              <div v-if="isCreating" class="form-text text-muted">
+                snake_case only: lowercase letters, digits, and underscores (e.g.
+                <code>my_prompt</code>)
+              </div>
+              <div
+                v-if="isCreating && editName && !/^[a-z][a-z0-9_]*$/.test(editName)"
+                class="invalid-feedback"
+              >
+                Must be snake_case and start with a lowercase letter.
+              </div>
             </div>
 
             <div class="mb-3">
@@ -535,13 +599,18 @@ onMounted(() => {
             <div class="mb-3 prompt-text-wrapper">
               <label class="form-label">Prompt Text</label>
 
-              <Editor v-model="editText" filename="prompt.md" :disabled="!canEdit" :wrap="true" />
+              <div :class="{ 'border border-danger rounded': saveAttempted && !editText.trim() }">
+                <Editor v-model="editText" filename="prompt.md" :disabled="!canEdit" :wrap="true" />
+              </div>
+              <div v-if="saveAttempted && !editText.trim()" class="text-danger small mt-1">
+                Prompt text is required.
+              </div>
             </div>
 
             <div class="d-flex gap-2">
-              <button class="btn btn-primary" :disabled="!canEdit || saving" @click="savePrompt">
+              <button class="btn btn-primary" :disabled="!canEdit || saving" @click="save">
                 <span v-if="saving" class="spinner-border spinner-border-sm me-1"></span>
-                {{ isCreating ? 'Create Prompt' : 'Save as New Version' }}
+                {{ saveLabel }}
               </button>
 
               <button

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -163,6 +163,7 @@ import MarkButton from './components/MarkButton.vue';
 import TaskDetail from './Student/TaskDetail.vue';
 import SyncLoader from './components/SyncLoader.vue';
 import EditTask from './Teacher/EditTask/EditTask.vue';
+import PromptEditor from './Teacher/PromptEditor.vue';
 
 const router = createRouter({
     history: createWebHistory(),
@@ -261,6 +262,14 @@ function mountMarkButton(id, props) {
     app.mount(id);
 }
 
+function mountPromptEditor(id, props) {
+    const app = createApp(PromptEditor, {
+        isSuperAdmin: props.is_superuser,
+        username: props.username
+    });
+    app.mount(id);
+}
+
 async function mountEditTask(id) {
     const app = createApp(EditTask);
     app.use(router);
@@ -273,3 +282,4 @@ window.mountQuiz = mountQuiz;
 window.mountQuizEdit = mountQuizEdit;
 window.mountMarkButton = mountMarkButton;
 window.mountEditTask = mountEditTask;
+window.mountPromptEditor = mountPromptEditor;

--- a/templates/web/layout.html
+++ b/templates/web/layout.html
@@ -51,6 +51,7 @@
                   <li class="nav-item"><a class="nav-link" href="{% url 'submits' %}">Submits</a></li>
                   <li class="nav-item"><a class="nav-link" href="{% url 'tasks' %}">Tasks</a></li>
                     <li class="nav-item"><a class="nav-link" href="{% url 'quiz_list' %}">Quizzes</a></li>
+                  <li class="nav-item"><a class="nav-link" href="{% url 'prompt_editor' %}">Prompts</a></li>
                   <li class="nav-item"><a class="nav-link" href="{% url 'students' %}">Students</a></li>
                   {% if request.path != student_index_url %}
                     <li class="nav-item"><a class="nav-link" href="{% url 'student_index' %}">Student view</a></li>

--- a/templates/web/prompt_editor.html
+++ b/templates/web/prompt_editor.html
@@ -1,0 +1,16 @@
+{% extends 'web/layout.html' %}
+
+{% block title %}Prompt Editor - Kelvin{% endblock %}
+
+{% block content %}
+    <div id="prompt-editor"></div>
+{% endblock %}
+
+{% block script %}
+{{ data|json_script:"prompt-editor-data" }}
+
+<script type="text/javascript">
+    const promptEditorData = JSON.parse(document.getElementById("prompt-editor-data").textContent);
+    mountPromptEditor("#prompt-editor", promptEditorData);
+</script>
+{% endblock %}

--- a/web/urls.py
+++ b/web/urls.py
@@ -174,4 +174,5 @@ urlpatterns = [
     path("teacher/quiz/scoring/<int:enrolled_id>", teacher_view.quiz_scoring, name="quiz_scoring"),
     path("teacher/quizzes", teacher_view.quiz_list, name="quiz_list"),
     path("teacher/quiz/<int:quiz_id>/submits", teacher_view.quiz_submits, name="quiz_submits"),
+    path("teacher/prompts", teacher_view.prompt_editor, name="prompt_editor"),
 ] + static("/.well-known", document_root="web/static/.well-known")

--- a/web/views/teacher.py
+++ b/web/views/teacher.py
@@ -408,6 +408,18 @@ def quiz_list(request: HttpRequest) -> HttpResponse:
 
 
 @user_passes_test(is_teacher)
+def prompt_editor(request: HttpRequest) -> HttpResponse:
+    """
+    Page that renders a Vue component for LLM prompt editing.
+    """
+    data = dict(
+        is_superuser=request.user.is_superuser,
+        username=request.user.username,
+    )
+    return render(request, "web/prompt_editor.html", dict(data=data))
+
+
+@user_passes_test(is_teacher)
 def quiz_submits(request: HttpRequest, quiz_id: int) -> HttpResponse:
     """
     Function that renders page with submits for quiz and its assigned classes.


### PR DESCRIPTION
This PR adds editor for teachers to manage prompts. There must be always default one, but if teacher wants to adjust prompt to focus on specific things, this is the way.

For example by default, there will be only prompt for C, CPP. But since other languages don't have same issues, eq. memory-leaks by free. Prompt need to be adjusted.

<img width="2560" height="1273" alt="image" src="https://github.com/user-attachments/assets/4d58d7fa-92a3-43c0-9293-e330168e5a78" />
