### PR TITLE
Include quizzes for Ruff formatting checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ include = [
     "common/**/*.py",
     "evaluator/**/*.py",
     "kelvin/**/*.py",
+    "quiz/**/*.py",
     "survey/**/*.py",
     "web/**/*.py"
 ]

--- a/quiz/middleware.py
+++ b/quiz/middleware.py
@@ -3,6 +3,7 @@ from django.urls import reverse, resolve, Resolver404
 from enum import Enum
 from kelvin.settings import DEBUG
 from quiz.quiz_utils import quiz_running_for_user
+
 if DEBUG:
     try:
         from debug_toolbar.toolbar import DebugToolbar


### PR DESCRIPTION
I just noticed that `uv run ruff format` didn't run for `quiz` module. I decided to add it to include paths in `pyproject.toml` and also run that aforementioned command to make sure the module is properly formatted. It wasn't. :)