### PR TITLE
Fix ESLint warnings

### DIFF
--- a/frontend/src/Quiz/Lists/QuizList.vue
+++ b/frontend/src/Quiz/Lists/QuizList.vue
@@ -265,8 +265,12 @@ const filterChanged = () => {
           <div class="col-12 mb-1">
             <label for="subject-select" class="form-label">Subject</label>
             <select id="subject-select" v-model="selectedSubjectAbbr" class="form-control">
-              <option v-for="subject in subjects" :key="subject.abbr" :value="subject.abbr">
-                {{ subject.name }}
+              <option
+                v-for="subjectItem in subjects"
+                :key="subjectItem.abbr"
+                :value="subjectItem.abbr"
+              >
+                {{ subjectItem.name }}
               </option>
             </select>
           </div>

--- a/frontend/src/Quiz/Lists/QuizSubmitList.vue
+++ b/frontend/src/Quiz/Lists/QuizSubmitList.vue
@@ -12,8 +12,8 @@ import { getFromAPI } from '../../utilities/api';
 
 DataTable.use(DataTablesCore);
 
-const { quiz_id } = defineProps<{
-  quiz_id: number;
+const { quizId } = defineProps<{
+  quizId: number;
 }>();
 
 type Submit = {
@@ -63,7 +63,7 @@ const getSubmits = async (
   const data = await getFromAPI<{
     submits: Submit[];
     count: number;
-  }>(`/api/quiz/${quiz_id}/submits${classPath}?${params.toString()}`);
+  }>(`/api/quiz/${quizId}/submits${classPath}?${params.toString()}`);
 
   if (data) {
     return [
@@ -94,7 +94,7 @@ const classes = ref(Array<Class>());
 const getClasses = async () => {
   const data = await getFromAPI<{
     classes: Class[];
-  }>(`/api/quiz/${quiz_id}/classes`);
+  }>(`/api/quiz/${quizId}/classes`);
 
   if (data) {
     classes.value = data.classes;

--- a/frontend/src/Quiz/Quiz.vue
+++ b/frontend/src/Quiz/Quiz.vue
@@ -357,7 +357,9 @@ onUnmounted(() => {
                   ></textarea>
                 </template>
                 <h6 class="mt-2"><strong>Question:</strong></h6>
-                <div v-html="question.htmlContent"></div>
+                <!-- eslint-disable vue/no-v-html -->
+                <div v-html="question.htmlContent" />
+                <!-- eslint-enable -->
                 <h6 v-if="question.type === 'open' || question.type === 'abcd'" class="mt-2">
                   <strong>Answer:</strong>
                 </h6>
@@ -391,7 +393,9 @@ onUnmounted(() => {
                     :key="answer.id"
                     class="row border rounded mt-2 p-2"
                   >
-                    <div class="col-11" v-html="answer.htmlContent"></div>
+                    <!-- eslint-disable vue/no-v-html -->
+                    <div class="col-11" v-html="answer.htmlContent" />
+                    <!-- eslint-enable -->
                     <div class="col-1 text-center align-self-center">
                       <input
                         v-if="!isScoring"

--- a/frontend/src/Quiz/QuizAssign.vue
+++ b/frontend/src/Quiz/QuizAssign.vue
@@ -10,9 +10,9 @@ import '@vuepic/vue-datepicker/dist/main.css';
 import 'vue3-toastify/dist/index.css';
 import { getDataWithCSRF } from '../utilities/api';
 
-const { assignments, quiz_id, teacher } = defineProps<{
+const { assignments, quizId, teacher } = defineProps<{
   assignments: string;
-  quiz_id: number;
+  quizId: number;
   teacher: string;
 }>();
 
@@ -67,7 +67,7 @@ const saveAssignments = async () => {
     message: string;
     quiz_deletable: boolean;
     assignments: AssignmentClass[];
-  }>(`/api/quiz/${quiz_id}/assignments`, 'POST', { assignments: assignmentsData.value });
+  }>(`/api/quiz/${quizId}/assignments`, 'POST', { assignments: assignmentsData.value });
 
   if (data) {
     toast.success(data.message);

--- a/frontend/src/Quiz/QuizEdit.vue
+++ b/frontend/src/Quiz/QuizEdit.vue
@@ -648,7 +648,7 @@ onUnmounted(() => {
     <div class="col-12 mb-2">
       <quizAssign
         v-model="isDeletableRef"
-        :quiz_id="props.quizEditData.id"
+        :quiz-id="props.quizEditData.id"
         :assignments="props.quizEditData.assignments"
         :teacher="props.quizEditData.teacher"
       ></quizAssign>
@@ -812,11 +812,9 @@ onUnmounted(() => {
             aria-labelledby="preview-tab"
           >
             <div class="col-12">
-              <div
-                id="preview-block-content"
-                ref="previewBlockContent"
-                v-html="previewHtmlRef"
-              ></div>
+              <!-- eslint-disable vue/no-v-html -->
+              <div id="preview-block-content" ref="previewBlockContent" v-html="previewHtmlRef" />
+              <!-- eslint-enable -->
             </div>
           </div>
         </div>

--- a/frontend/src/Student/TaskDetail.vue
+++ b/frontend/src/Student/TaskDetail.vue
@@ -14,7 +14,7 @@ import { Comment, SelectedRows, Source, Submit } from '../types/TaskDetail';
 
 const props = defineProps<{
   url: string;
-  comment_url: string;
+  commentUrl: string;
 }>();
 
 const files = ref<SourceFile[] | null>(null);
@@ -178,7 +178,7 @@ type CommentSavePayload = {
 const addNewComment = async (comment: CommentSavePayload) => {
   const { success, ...payload } = comment;
 
-  const res = await fetch(props.comment_url, {
+  const res = await fetch(props.commentUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -218,7 +218,7 @@ const addNewComment = async (comment: CommentSavePayload) => {
 };
 
 const updateComment = async (id: number, text: string) => {
-  await fetch(`${props.comment_url}/${id}`, {
+  await fetch(`${props.commentUrl}/${id}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json'
@@ -663,7 +663,7 @@ onUnmounted(() => {
     <SubmitsDiff
       v-if="showDiff"
       :submits="submits"
-      :current_submit="current_submit"
+      :current-submit="current_submit"
       :deadline="deadline"
     />
 

--- a/frontend/src/Teacher/EditTask/AutoCompleteTaskPath.vue
+++ b/frontend/src/Teacher/EditTask/AutoCompleteTaskPath.vue
@@ -119,6 +119,7 @@ watch(selectedId, () => {
     </div>
 
     <ul v-if="filtered.length && focused">
+      <!-- eslint-disable vue/no-v-html -->
       <li
         v-for="(item, i) in filtered"
         :key="i"
@@ -132,7 +133,8 @@ watch(selectedId, () => {
         v-html="
           item.path.replace(new RegExp('(' + escapeRegExp(path) + ')', 'gi'), '<strong>$1</strong>')
         "
-      ></li>
+      />
+      <!-- eslint-enable -->
     </ul>
   </div>
 </template>

--- a/frontend/src/Teacher/EditTask/FileManager.vue
+++ b/frontend/src/Teacher/EditTask/FileManager.vue
@@ -284,8 +284,8 @@ function closeTab(path: string) {
 
   <div
     v-if="ctxMenu && ctxMenu.selected != '/readme.md'"
-    class="dropdown-menu show"
     v-click-outside="() => (ctxMenu = null)"
+    class="dropdown-menu show"
     :style="{ position: 'fixed', top: ctxMenu.top + 'px', left: ctxMenu.left + 'px' }"
   >
     <button

--- a/frontend/src/Teacher/EditTask/Tests.vue
+++ b/frontend/src/Teacher/EditTask/Tests.vue
@@ -254,8 +254,8 @@ load();
 
         <div class="btn-group" role="group" aria-label="Basic example">
           <input
-            type="text"
             v-model="new_test_io_file[name]"
+            type="text"
             class="form-control form-control-sm"
             placeholder="Filename"
           />

--- a/frontend/src/Teacher/student-page/EventList.vue
+++ b/frontend/src/Teacher/student-page/EventList.vue
@@ -235,13 +235,13 @@ watch(ipFilter, () => {
     </div>
 
     <DataTable ref="dt" class="table table-striped" :columns="columns" :options="options">
-      <template #column-link="props">
-        <div v-if="props.rowData.metadata && props.rowData.metadata.link">
-          <a :href="props.rowData.metadata.link" target="_blank">
-            {{ props.rowData.metadata.task_name }}
+      <template #column-link="columnLinkProps">
+        <div v-if="columnLinkProps.rowData.metadata && columnLinkProps.rowData.metadata.link">
+          <a :href="columnLinkProps.rowData.metadata.link" target="_blank">
+            {{ columnLinkProps.rowData.metadata.task_name }}
             {{
-              props.rowData.metadata.submit_num != undefined
-                ? '#' + props.rowData.metadata.submit_num
+              columnLinkProps.rowData.metadata.submit_num != undefined
+                ? '#' + columnLinkProps.rowData.metadata.submit_num
                 : ''
             }}
           </a>

--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -156,7 +156,7 @@ const readAll = async () => {
                 >
                   {{ item.action_object }}
                 </a>
-                <template v-else>{item.action_object}</template>
+                <template v-else>{{ item.action_object }}</template>
 
                 <template v-if="item.target"> on {{ item.target }}</template>
               </template>

--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -143,7 +143,9 @@ const readAll = async () => {
           >
             <div>
               <strong>{{ item.actor }}&nbsp;</strong>
+              <!-- eslint-disable vue/no-v-html -->
               <div v-if="item.custom_text" v-html="item.custom_text" />
+              <!-- eslint-enable -->
 
               <template v-else>
                 {{ item.verb }}

--- a/frontend/src/components/__snapshots__/Notifications.test.ts.snap
+++ b/frontend/src/components/__snapshots__/Notifications.test.ts.snap
@@ -38,7 +38,7 @@ exports[`Notifications > Read notification 1`] = `
         </div>
       </li>
       <li class="list-group-item p-1 d-flex align-items-center justify-content-between text-body-secondary">
-        <div><strong>some-actor2&nbsp;</strong>
+        <div><strong>some-actor2&nbsp;</strong><!-- eslint-disable vue/no-v-html -->
           <div>some-custom-text2</div><span>&nbsp;(<time datetime="1999-12-31T23:00:00.000Z" title="1. 1. 2000 0:00:00"><!--v-if-->25 years ago<!--v-if--></time>) </span>
         </div>
         <div><button type="button" hidden="" class="btn-close" aria-label="Close"></button></div>
@@ -65,13 +65,13 @@ exports[`Notifications > Wait for notification 1`] = `
         </div>
       </li>
       <li class="list-group-item p-1 d-flex align-items-center justify-content-between text-body-secondary">
-        <div><strong>some-actor1&nbsp;</strong>
+        <div><strong>some-actor1&nbsp;</strong><!-- eslint-disable vue/no-v-html -->
           <div>some-custom-text</div><span>&nbsp;(<time datetime="1999-12-31T23:00:00.000Z" title="1. 1. 2000 0:00:00"><!--v-if-->25 years ago<!--v-if--></time>) </span>
         </div>
         <div><button type="button" hidden="" class="btn-close" aria-label="Close"></button></div>
       </li>
       <li class="list-group-item p-1 d-flex align-items-center justify-content-between text-body-secondary">
-        <div><strong>some-actor2&nbsp;</strong>
+        <div><strong>some-actor2&nbsp;</strong><!-- eslint-disable vue/no-v-html -->
           <div>some-custom-text2</div><span>&nbsp;(<time datetime="1999-12-31T23:00:00.000Z" title="1. 1. 2000 0:00:00"><!--v-if-->25 years ago<!--v-if--></time>) </span>
         </div>
         <div><button type="button" hidden="" class="btn-close" aria-label="Close"></button></div>

--- a/frontend/src/components/submit/CodeRow.vue
+++ b/frontend/src/components/submit/CodeRow.vue
@@ -68,7 +68,9 @@ const addNewComment = (text: string) => {
     </td>
 
     <td>
-      <pre v-html="line"></pre>
+      <!-- eslint-disable vue/no-v-html -->
+      <pre v-html="line" />
+      <!-- eslint-enable -->
 
       <template v-for="comment in comments || []" :key="comment.id">
         <SuggestedComment

--- a/frontend/src/components/submit/Comment.vue
+++ b/frontend/src/components/submit/Comment.vue
@@ -9,24 +9,24 @@ import { useSvelteStore } from '../../utilities/useSvelteStore';
 const props = withDefaults(
   defineProps<{
     author?: string;
-    author_id?: number | null;
+    authorId?: number | null;
     text?: string;
     type?: string;
     id?: number | null;
-    can_edit?: boolean;
+    canEdit?: boolean;
     unread?: boolean | null;
-    notification_id?: number | null;
+    notificationId?: number | null;
     meta?: { url?: string; review?: { id: number } } | null;
   }>(),
   {
     author: '',
-    author_id: null,
+    authorId: null,
     text: '',
     type: '',
     id: null,
-    can_edit: false,
+    canEdit: false,
     unread: null,
-    notification_id: null,
+    notificationId: null,
     meta: null
   }
 );
@@ -72,7 +72,7 @@ const handleNotification = () => {
     <div
       class="comment"
       :class="[`comment-${unread ? 'unread' : 'read'}`, type]"
-      @dblclick="editing = can_edit"
+      @dblclick="editing = canEdit"
     >
       <strong>{{ author }}: </strong>
 
@@ -86,7 +86,7 @@ const handleNotification = () => {
 
         <template v-else-if="currentUser">
           <button
-            v-if="unread && author_id !== currentUser.id"
+            v-if="unread && authorId !== currentUser.id"
             class="btn p-0 float-end"
             style="line-height: normal"
             @click.prevent="handleNotification"
@@ -94,7 +94,9 @@ const handleNotification = () => {
             <span class="iconify" data-icon="cil-check"></span>
           </button>
 
-          <span v-html="safeMarkdown(text)"></span>
+          <!-- eslint-disable vue/no-v-html -->
+          <span v-html="safeMarkdown(text)" />
+          <!-- eslint-enable -->
         </template>
       </template>
 

--- a/frontend/src/components/submit/SubmitsDiff.vue
+++ b/frontend/src/components/submit/SubmitsDiff.vue
@@ -21,7 +21,7 @@ declare global {
 const props = withDefaults(
   defineProps<{
     submits?: Submit[];
-    current_submit: number;
+    currentSubmit: number;
     deadline: number | string | Date;
   }>(),
   {
@@ -30,7 +30,7 @@ const props = withDefaults(
 );
 
 const a = ref(1);
-const b = ref(props.current_submit);
+const b = ref(props.currentSubmit);
 const diffHtmlOutput = ref('');
 
 const formatInfo = (submit: Submit) => {
@@ -52,7 +52,7 @@ const formatInfo = (submit: Submit) => {
 };
 
 watch(
-  () => props.current_submit,
+  () => props.currentSubmit,
   (value) => {
     if (value != null) {
       a.value = Math.max(value - 1, 1);
@@ -113,7 +113,9 @@ watch(
       </span>
     </li>
 
-    <div class="code-diff" v-html="diffHtmlOutput"></div>
+    <!-- eslint-disable vue/no-v-html -->
+    <div class="code-diff" v-html="diffHtmlOutput" />
+    <!-- eslint-enable -->
   </ul>
 </template>
 

--- a/frontend/src/components/submit/SuggestedComment.vue
+++ b/frontend/src/components/submit/SuggestedComment.vue
@@ -264,7 +264,9 @@ const handleRating = async (rating: number) => {
         </div>
       </div>
 
-      <div v-if="!editing" class="comment-text" v-html="safeMarkdown(text)"></div>
+      <!-- eslint-disable vue/no-v-html -->
+      <div v-if="!editing" class="comment-text" v-html="safeMarkdown(text)" />
+      <!-- eslint-enable -->
       <CommentForm v-else :comment="text" :disabled="sending" @save="handleSave" />
     </div>
   </div>


### PR DESCRIPTION
Another detail that annoyed me during development: there are a few files that produce warnings in ESLint, and they were even easy to fix just by running `npm run fix`. When I was into it, we have many places where we use `v-html` which is obviously considered insecure unless we know what will be in such elements or how we are using it. I suppressed those warnings, because they are reported in every single PR even though we know the use of `v-html` is intentional.

As a bonus, I noticed a small detail in the `Notifications` component, when there's no `action_object_url`, an `action_object` string should be displayed, but someone forgot to add double curly braces to make it work. Tests for `Notifications` component were also failing because of the ESLint warning suppression, so I made a new snapshot.

The entire frontend codebase is now properly formatted with Prettier and without ESLint warnings.