### PR TITLE
Fix inability to edit comments

### DIFF
--- a/frontend/src/components/submit/CodeRow.vue
+++ b/frontend/src/components/submit/CodeRow.vue
@@ -75,13 +75,13 @@ const addNewComment = (text: string) => {
       <template v-for="comment in comments || []" :key="comment.id">
         <SuggestedComment
           v-if="comment.type === 'ai-review'"
-          v-bind="comment"
+          :comment="comment"
           @resolve-suggestion="emit('resolveSuggestion', $event)"
         />
 
         <Comment
           v-else
-          v-bind="comment"
+          :comment="comment"
           @save-comment="emit('saveComment', $event)"
           @set-notification="emit('setNotification', $event)"
         />

--- a/frontend/src/components/submit/Comment.vue
+++ b/frontend/src/components/submit/Comment.vue
@@ -6,30 +6,32 @@ import { safeMarkdown } from '../../markdown';
 import { hideComments, HideCommentsState } from '../../stores';
 import { useSvelteStore } from '../../utilities/useSvelteStore';
 
+/* eslint-disable vue/prop-name-casing */
 const props = withDefaults(
   defineProps<{
     author?: string;
-    authorId?: number | null;
+    author_id?: number | null;
     text?: string;
     type?: string;
     id?: number | null;
-    canEdit?: boolean;
+    can_edit?: boolean;
     unread?: boolean | null;
-    notificationId?: number | null;
+    notification_id?: number | null;
     meta?: { url?: string; review?: { id: number } } | null;
   }>(),
   {
     author: '',
-    authorId: null,
+    author_id: null,
     text: '',
     type: '',
     id: null,
-    canEdit: false,
+    can_edit: false,
     unread: null,
-    notificationId: null,
+    notification_id: null,
     meta: null
   }
 );
+/* eslint-enable vue/prop-name-casing */
 
 const emit = defineEmits(['saveComment', 'setNotification']);
 
@@ -72,7 +74,7 @@ const handleNotification = () => {
     <div
       class="comment"
       :class="[`comment-${unread ? 'unread' : 'read'}`, type]"
-      @dblclick="editing = canEdit"
+      @dblclick="editing = can_edit"
     >
       <strong>{{ author }}: </strong>
 
@@ -86,7 +88,7 @@ const handleNotification = () => {
 
         <template v-else-if="currentUser">
           <button
-            v-if="unread && authorId !== currentUser.id"
+            v-if="unread && author_id !== currentUser.id"
             class="btn p-0 float-end"
             style="line-height: normal"
             @click.prevent="handleNotification"

--- a/frontend/src/components/submit/Comment.vue
+++ b/frontend/src/components/submit/Comment.vue
@@ -5,33 +5,11 @@ import { user } from '../../global';
 import { safeMarkdown } from '../../markdown';
 import { hideComments, HideCommentsState } from '../../stores';
 import { useSvelteStore } from '../../utilities/useSvelteStore';
+import { Comment } from '../../types/TaskDetail';
 
-/* eslint-disable vue/prop-name-casing */
-const props = withDefaults(
-  defineProps<{
-    author?: string;
-    author_id?: number | null;
-    text?: string;
-    type?: string;
-    id?: number | null;
-    can_edit?: boolean;
-    unread?: boolean | null;
-    notification_id?: number | null;
-    meta?: { url?: string; review?: { id: number } } | null;
-  }>(),
-  {
-    author: '',
-    author_id: null,
-    text: '',
-    type: '',
-    id: null,
-    can_edit: false,
-    unread: null,
-    notification_id: null,
-    meta: null
-  }
-);
-/* eslint-enable vue/prop-name-casing */
+const props = defineProps<{
+  comment: Comment;
+}>();
 
 const emit = defineEmits(['saveComment', 'setNotification']);
 
@@ -44,7 +22,10 @@ const currentHideComments = useSvelteStore(hideComments, HideCommentsState.NONE)
 const showComment = computed(() => {
   return (
     currentHideComments.value !== HideCommentsState.ALL &&
-    !(currentHideComments.value === HideCommentsState.AUTOMATED && props.type === 'automated')
+    !(
+      currentHideComments.value === HideCommentsState.AUTOMATED &&
+      props.comment.type === 'automated'
+    )
   );
 });
 
@@ -52,7 +33,7 @@ const updateComment = (text: string) => {
   sending.value = true;
 
   emit('saveComment', {
-    id: props.id,
+    id: props.comment.id,
     text,
     success: () => {
       editing.value = false;
@@ -63,8 +44,8 @@ const updateComment = (text: string) => {
 
 const handleNotification = () => {
   emit('setNotification', {
-    comment_id: props.id,
-    unread: !props.unread
+    comment_id: props.comment.id,
+    unread: !props.comment.unread
   });
 };
 </script>
@@ -73,22 +54,22 @@ const handleNotification = () => {
   <div v-if="showComment" style="display: flex; flex-direction: row">
     <div
       class="comment"
-      :class="[`comment-${unread ? 'unread' : 'read'}`, type]"
-      @dblclick="editing = can_edit"
+      :class="[`comment-${comment.unread ? 'unread' : 'read'}`, comment.type]"
+      @dblclick="editing = comment.can_edit"
     >
-      <strong>{{ author }}: </strong>
+      <strong>{{ comment.author }}: </strong>
 
       <template v-if="!editing">
-        <template v-if="type === 'automated'">
-          {{ text }}
-          <a v-if="meta && meta.url" :href="meta.url">
+        <template v-if="comment.type === 'automated'">
+          {{ comment.text }}
+          <a v-if="comment.meta && comment.meta.url" :href="comment.meta.url">
             <span class="iconify" data-icon="entypo:help"></span>
           </a>
         </template>
 
         <template v-else-if="currentUser">
           <button
-            v-if="unread && author_id !== currentUser.id"
+            v-if="comment.unread && comment.author_id !== currentUser.id"
             class="btn p-0 float-end"
             style="line-height: normal"
             @click.prevent="handleNotification"
@@ -97,12 +78,12 @@ const handleNotification = () => {
           </button>
 
           <!-- eslint-disable vue/no-v-html -->
-          <span v-html="safeMarkdown(text)" />
+          <span v-html="safeMarkdown(comment.text || '')" />
           <!-- eslint-enable -->
         </template>
       </template>
 
-      <CommentForm v-else :comment="text" :disabled="sending" @save="updateComment" />
+      <CommentForm v-else :comment="comment.text || ''" :disabled="sending" @save="updateComment" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/submit/SuggestedComment.vue
+++ b/frontend/src/components/submit/SuggestedComment.vue
@@ -10,15 +10,21 @@ import { fetch as apiFetch } from '../../api.js';
 import { Comment } from '../../types/TaskDetail';
 import { toastApi } from '../../utilities/toast';
 
-const props = withDefaults(defineProps<Comment & { summary?: boolean }>(), {
-  summary: false
-});
+const props = withDefaults(
+  defineProps<{
+    comment: Comment;
+    summary?: boolean;
+  }>(),
+  {
+    summary: false
+  }
+);
 
 const emit = defineEmits(['resolveSuggestion']);
 
 const editing = ref(false);
 const sending = ref(false);
-const committedRating = ref(props.meta.review.rating ?? 0);
+const committedRating = ref(props.comment.meta?.review?.rating ?? 0);
 
 const currentUser = useSvelteStore(user, null);
 const hideCommentsValue = useSvelteStore(hideComments, HideCommentsState.NONE);
@@ -72,7 +78,7 @@ const resolveSuggestion = async <T,>(
 
 const handleAccept = async () => {
   sending.value = true;
-  const suggestionId = props.meta.review.id;
+  const suggestionId = props.comment.meta?.review?.id;
 
   const { data, error } = await resolveSuggestion<Comment>(
     `/api/v2/llm/suggestions/${suggestionId}`,
@@ -106,7 +112,7 @@ const handleAccept = async () => {
 
 const handleReject = async () => {
   sending.value = true;
-  const suggestionId = props.meta.review.id;
+  const suggestionId = props.comment.meta?.review?.id;
 
   const { error } = await resolveSuggestion<{ status: string }>(
     `/api/v2/llm/suggestions/${suggestionId}`,
@@ -140,7 +146,7 @@ const handleEdit = () => {
 
 const handleSave = async (text: string) => {
   sending.value = true;
-  const suggestionId = props.meta.review.id;
+  const suggestionId = props.comment.meta?.review?.id;
 
   const { data, error } = await resolveSuggestion<Comment>(
     `/api/v2/llm/suggestions/${suggestionId}`,
@@ -178,7 +184,7 @@ const handleSave = async (text: string) => {
 
 const handleRating = async (rating: number) => {
   sending.value = true;
-  const suggestionId = props.meta.review.id;
+  const suggestionId = props.comment.meta?.review?.id;
 
   const previousRating = committedRating.value;
   committedRating.value = rating;
@@ -214,7 +220,7 @@ const handleRating = async (rating: number) => {
   <div class="suggested-comment" v-bind="$attrs">
     <div v-if="showComment && currentUser?.teacher" class="comment ai-review">
       <div class="comment-header">
-        <strong>{{ author }}</strong>
+        <strong>{{ comment.author }}</strong>
 
         <div v-if="currentUser?.teacher && !editing" class="comment-actions">
           <button
@@ -265,9 +271,9 @@ const handleRating = async (rating: number) => {
       </div>
 
       <!-- eslint-disable vue/no-v-html -->
-      <div v-if="!editing" class="comment-text" v-html="safeMarkdown(text)" />
+      <div v-if="!editing" class="comment-text" v-html="safeMarkdown(comment.text || '')" />
       <!-- eslint-enable -->
-      <CommentForm v-else :comment="text" :disabled="sending" @save="handleSave" />
+      <CommentForm v-else :comment="comment.text || ''" :disabled="sending" @save="handleSave" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/submit/SummaryComments.vue
+++ b/frontend/src/components/submit/SummaryComments.vue
@@ -32,14 +32,14 @@ const addComment = (text: string) => {
   <template v-for="comment in summaryComments" :key="comment.id">
     <SuggestedComment
       v-if="comment.type === 'ai-review'"
-      v-bind="comment"
+      :comment="comment"
       :summary="true"
       @resolve-suggestion="emit('resolveSuggestion', $event)"
     />
 
     <Comment
       v-else
-      v-bind="comment"
+      :comment="comment"
       @save-comment="emit('saveComment', $event)"
       @set-notification="emit('setNotification', $event)"
     />

--- a/templates/web/quiz/quiz_submit_list.html
+++ b/templates/web/quiz/quiz_submit_list.html
@@ -1,3 +1,3 @@
 {% extends 'web/layout.html' %} {% block content %}
-    <kelvin-quiz-submit-list quiz_id="{{ quiz_id }}"></kelvin-quiz-submit-list>
+    <kelvin-quiz-submit-list quiz-id="{{ quiz_id }}"></kelvin-quiz-submit-list>
 {% endblock %}


### PR DESCRIPTION
The ESLint fix (#852) changed prop bindings from API types in comments by forcing them to `camelCase`, which caused issues with both creating and editing comments. After trying multiple approaches to keep the properties in `camelCase`, I decided to revert them back to `snake_case` and suppress the ESLint warning for now.

I also reviewed my previous PR once more to identify any other possible issues. The only additional problem I found was incorrect passing of the `quizId` prop in the quiz submit list template in Django.

*BTW: I’m really impressed that Rust can automatically convert `camelCase` to `snake_case` for de-/serialization simply by using `#[serde(rename_all = "snake_case")]`. Sadly, I couldn’t find an equally straightforward solution in TypeScript. It seems the only option is to transform object keys (deeply) at runtime. The question is: should I investigate this further so we can use `camelCase` properties throughout the frontend while keeping the API in `snake_case`?*