### PR TITLE
Show late submits in students view

### DIFF
--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -86,6 +86,10 @@
                                                title="Go to latest submit">
                                                <span class="iconify" data-icon="bx:bx-check"></span>
                                             </a>
+                                        {% elif task.submits %}
+                                            <a href="{% url 'task_detail' login=task.student assignment_id=task.id submit_num=task.submits %}"
+                                               title="Go to latest submit">
+                                            <span class="iconify text-danger" data-icon="bx:bx-check"></span>
                                         {% else %}
                                             <span class="iconify" data-icon="bi:dash"></span>
                                         {%  endif  %}


### PR DESCRIPTION
If the first submit was after a deadline, user could see only a dash icon in the submitted column leaving him unsure if he submitted it or not. This PR add a simple red check icon, notifing the user he succesfully submited but after the set deadline. Maybe the different color is not needed, but wasn't sure about that.

Thought:
Go to latest submit in the first branch only takes you to the latest submit before deadline. Sure this is wanted but maybe it might be misleading. Maybe merging the 2 branches and just distinguish the late submits by the color, but jump really to the latest submit.

Current State:
<img width="2608" height="356" alt="Screenshot From 2026-05-13 19-19-57" src="https://github.com/user-attachments/assets/3361b82e-9a44-4a4e-8e47-435c73d8f951" />
