### PR TITLE
Reinstate scheduled tasks

### DIFF
--- a/common/management/commands/task_check_plagiarism.py
+++ b/common/management/commands/task_check_plagiarism.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from common.task_creator import create_repeatable_task
+
+
+class Command(BaseCommand):
+    """
+    Periodically run MOSS plagiarism check.
+    """
+
+    def handle(self, *args, **opts):
+        create_repeatable_task(
+            "moss-plagiarism-check",
+            "common.plagcheck.moss.periodic_moss_check",
+            interval=timedelta(minutes=15),
+            queue="default",
+        )

--- a/common/management/commands/task_prune_old_docker_containers.py
+++ b/common/management/commands/task_prune_old_docker_containers.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from common.cron_creator import create_crontask
+from common.task_creator import create_crontask
 import logging
 
 
@@ -8,7 +8,7 @@ class Command(BaseCommand):
         try:
             # We want to delete containers older than 30 minutes every hour
             create_crontask(
-                "deleter",
+                "docker-container-prune",
                 "evaluator.docker_container_cleanup.delete_old_containers",
                 cron_string="0 * * * *",
                 args=[("int", "1800")],

--- a/common/management/commands/task_send_email.py
+++ b/common/management/commands/task_send_email.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand
-from common.cron_creator import create_repeatable_task
+from common.task_creator import create_repeatable_task
 
 
 class Command(BaseCommand):
@@ -13,6 +13,6 @@ class Command(BaseCommand):
         create_repeatable_task(
             "email-send",
             "common.emails.try_send_email_from_queue",
-            queue="default",
             interval=timedelta(seconds=30),
+            queue="default",
         )

--- a/common/plagcheck/moss/__init__.py
+++ b/common/plagcheck/moss/__init__.py
@@ -290,7 +290,6 @@ def do_periodic_moss_check():
         enqueue_plagiarism_check(task.id, notify=True)
 
 
-# TODO: setup in code instead of UI (Django scheduler management command)
 @django_rq.job("default", timeout=60 * 15)
 def periodic_moss_check():
     do_periodic_moss_check()

--- a/common/task_creator.py
+++ b/common/task_creator.py
@@ -1,9 +1,9 @@
 import datetime
 from datetime import timedelta
 
-from scheduler.models import RepeatableTask
-from scheduler.models.scheduled_task import CronTask
+from scheduler.models.task import Task
 from scheduler.models.args import TaskArg
+from scheduler.tools import TaskType
 from django.contrib.contenttypes.models import ContentType
 from typing import List, Tuple
 
@@ -14,9 +14,9 @@ def create_crontask(
     cron_string: str,
     queue: str,
     args: List[Tuple[str, str]] | None = None,
-    enabled=True,
 ):
-    """Create a CronTask with the given parameters. If a task with the same name exists, it will be deleted first.
+    """
+    Create a CronTask with the given parameters. If a task with the same name exists, it will be deleted first.
 
     Keyword arguments:
     name -- The name of the cron task.
@@ -24,19 +24,19 @@ def create_crontask(
     cron_string -- The cron schedule string.
     queue -- The queue in which the task will be executed.
     args -- A list of tuples representing the arguments for the task.
-    enabled -- Whether the cron task is enabled.
     """
-    existing_job = CronTask.objects.filter(name=name).first()
+    existing_job = Task.objects.filter(name=name).first()
     if existing_job:
         existing_job.delete()
-    job = CronTask.objects.create(
+    job = Task.objects.create(
         name=name,
+        task_type=TaskType.CRON,
         callable=callable,
-        enabled=enabled,
+        enabled=True,
         queue=queue,
         cron_string=cron_string,
     )
-    content_type = ContentType.objects.get_for_model(CronTask)
+    content_type = ContentType.objects.get_for_model(Task)
     for arg in args or []:
         TaskArg.objects.create(
             object_id=job.id,
@@ -52,19 +52,21 @@ def create_repeatable_task(
     interval: timedelta,
     queue: str,
 ):
-    """Create a RepeatableTask (from django-tasks-scheduler) with the given `interval`.
+    """
+    Create a repeatable Task (from django-tasks-scheduler) with the given `interval`.
     If a task with the same name exists, it will be deleted first.
     """
-    existing_job = RepeatableTask.objects.filter(name=name).first()
+    existing_job = Task.objects.filter(name=name).first()
     if existing_job:
         existing_job.delete()
-    RepeatableTask.objects.create(
+    Task.objects.create(
         name=name,
+        task_type=TaskType.REPEATABLE,
         callable=callable,
         enabled=True,
         queue=queue,
         interval=int(interval.total_seconds()),
-        interval_unit=RepeatableTask.TimeUnits.SECONDS,
+        interval_unit=Task.TimeUnits.SECONDS,
         scheduled_time=datetime.datetime.now(datetime.UTC),
         # Run forever
         repeat=None,


### PR DESCRIPTION
This PR encodes all our current scheduled tasks into separate commands, so that we can easily add/modify them using the Django CLI. The code has also been updated to work with version 3 of `django-tasks-scheduler`.
